### PR TITLE
chore: add .claudeignore

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,4 @@
+node_modules/
+.expo/
+ios/Pods/
+package-lock.json


### PR DESCRIPTION
Excludes node_modules, .expo, ios/Pods, package-lock.json from Claude Code indexing.