### PR TITLE
feat: RevenueCat SDK upgrade — paywall, customer center, yearly plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-error.*
 *.pem
 
 # local env files
+.env
 .env*.local
 
 # typescript

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,4 +118,4 @@ Environment is resolved in `services/config.js`.
 - Auth events broadcast via `authService.subscribeAuthEvents()` for cross-component coordination
 - Subscription lapse detection compares the AsyncStorage-persisted `subscription_last_known_state` with live RevenueCat data; if this key is absent (e.g., after logout, first install, or manual storage clear), the lapse modal is suppressed
 - RevenueCat SDK is configured on SubscriptionProvider mount; the refresh function guards against use before configuration via `isConfiguredRef`, but the real-time listener only registers after `sdkConfigured` state flips to true
-- `canGenerate` is derived in two reducer branches (`SET_CUSTOMER_INFO` and `SET_TRIAL_STATUS`) because either data source may update independently
+- `canGenerate` is derived in a `useMemo` that falls back to `isSubscribed || trial.active` when `backendCanGenerate` is null; the reducer receives `backendCanGenerate` from the backend via `SET_REFRESH_COMPLETE` and `SET_TRIAL_STATUS`, while `SET_CUSTOMER_INFO` may reset it to null when the entitlement direction changes — these are all independent update paths

--- a/hooks/__tests__/useSubscription.test.js
+++ b/hooks/__tests__/useSubscription.test.js
@@ -31,6 +31,10 @@ const mockOnCustomerInfoUpdate = jest.fn();
 
 let mockCustomerInfoUpdateCallback = null;
 
+const mockPresentPaywall = jest.fn().mockResolvedValue({ success: true, data: 'CANCELLED' });
+const mockPresentPaywallIfNeeded = jest.fn().mockResolvedValue({ success: true, data: 'NOT_PRESENTED' });
+const mockPresentCustomerCenter = jest.fn().mockResolvedValue({ success: true, data: null });
+
 jest.mock('../../services/subscriptionService', () => {
   const actual = jest.requireActual('../../services/subscriptionService');
   return {
@@ -42,7 +46,17 @@ jest.mock('../../services/subscriptionService', () => {
     restorePurchases: (...args) => mockRestorePurchasesService(...args),
     getCustomerInfo: (...args) => mockGetCustomerInfo(...args),
     onCustomerInfoUpdate: (...args) => mockOnCustomerInfoUpdate(...args),
-    parseCustomerInfo: actual.parseCustomerInfo
+    parseCustomerInfo: actual.parseCustomerInfo,
+    presentPaywall: (...args) => mockPresentPaywall(...args),
+    presentPaywallIfNeeded: (...args) => mockPresentPaywallIfNeeded(...args),
+    presentCustomerCenter: (...args) => mockPresentCustomerCenter(...args),
+    PAYWALL_RESULT: {
+      PURCHASED: 'PURCHASED',
+      RESTORED: 'RESTORED',
+      CANCELLED: 'CANCELLED',
+      NOT_PRESENTED: 'NOT_PRESENTED',
+      ERROR: 'ERROR',
+    }
   };
 });
 
@@ -406,7 +420,7 @@ describe('SubscriptionProvider', () => {
           customerInfo: {
             entitlements: {
               active: {
-                premium: { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
+                'DawnoTemu Subscription': { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
               }
             }
           },
@@ -548,7 +562,7 @@ describe('SubscriptionProvider', () => {
         data: {
           entitlements: {
             active: {
-              premium: { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
+              'DawnoTemu Subscription': { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
             }
           }
         }
@@ -559,7 +573,7 @@ describe('SubscriptionProvider', () => {
         data: {
           entitlements: {
             active: {
-              premium: { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
+              'DawnoTemu Subscription': { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
             }
           }
         }
@@ -598,7 +612,7 @@ describe('SubscriptionProvider', () => {
         data: {
           entitlements: {
             active: {
-              premium: { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
+              'DawnoTemu Subscription': { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
             }
           }
         }
@@ -630,7 +644,7 @@ describe('SubscriptionProvider', () => {
         mockCustomerInfoUpdateCallback({
           entitlements: {
             active: {
-              premium: { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
+              'DawnoTemu Subscription': { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
             }
           }
         });
@@ -663,7 +677,7 @@ describe('SubscriptionProvider', () => {
           customerInfo: {
             entitlements: {
               active: {
-                premium: { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
+                'DawnoTemu Subscription': { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
               }
             }
           },
@@ -812,7 +826,7 @@ describe('SubscriptionProvider', () => {
         data: {
           entitlements: {
             active: {
-              premium: { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
+              'DawnoTemu Subscription': { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
             }
           }
         }
@@ -915,7 +929,7 @@ describe('SubscriptionProvider', () => {
           customerInfo: {
             entitlements: {
               active: {
-                premium: { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
+                'DawnoTemu Subscription': { expirationDate: '2026-12-01T00:00:00Z', willRenew: true }
               }
             }
           },

--- a/hooks/__tests__/useSubscription.test.js
+++ b/hooks/__tests__/useSubscription.test.js
@@ -867,6 +867,205 @@ describe('SubscriptionProvider', () => {
     });
   });
 
+  describe('presentPaywall', () => {
+    test('refreshes subscription state after PURCHASED result', async () => {
+      mockPresentPaywall.mockResolvedValueOnce({ success: true, data: 'PURCHASED' });
+
+      const { result } = renderHook(
+        () => ({ state: useSubscription(), actions: useSubscriptionActions() }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      const customerInfoCallsBefore = mockGetCustomerInfo.mock.calls.length;
+
+      let paywallResult;
+      await act(async () => {
+        paywallResult = await result.current.actions.presentPaywall({ displayCloseButton: true });
+      });
+
+      expect(paywallResult.success).toBe(true);
+      expect(paywallResult.data).toBe('PURCHASED');
+      expect(mockGetCustomerInfo.mock.calls.length).toBeGreaterThan(customerInfoCallsBefore);
+    });
+
+    test('refreshes subscription state after RESTORED result', async () => {
+      mockPresentPaywall.mockResolvedValueOnce({ success: true, data: 'RESTORED' });
+
+      const { result } = renderHook(
+        () => ({ state: useSubscription(), actions: useSubscriptionActions() }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      const customerInfoCallsBefore = mockGetCustomerInfo.mock.calls.length;
+
+      await act(async () => {
+        await result.current.actions.presentPaywall({ displayCloseButton: true });
+      });
+
+      expect(mockGetCustomerInfo.mock.calls.length).toBeGreaterThan(customerInfoCallsBefore);
+    });
+
+    test('does not refresh after CANCELLED result', async () => {
+      mockPresentPaywall.mockResolvedValueOnce({ success: true, data: 'CANCELLED' });
+
+      const { result } = renderHook(
+        () => ({ state: useSubscription(), actions: useSubscriptionActions() }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      const customerInfoCallsBefore = mockGetCustomerInfo.mock.calls.length;
+
+      await act(async () => {
+        await result.current.actions.presentPaywall({ displayCloseButton: true });
+      });
+
+      expect(mockGetCustomerInfo.mock.calls.length).toBe(customerInfoCallsBefore);
+    });
+
+    test('returns error on failure without throwing', async () => {
+      mockPresentPaywall.mockRejectedValueOnce(new Error('Paywall crashed'));
+
+      const { result } = renderHook(
+        () => ({ state: useSubscription(), actions: useSubscriptionActions() }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      let paywallResult;
+      await act(async () => {
+        paywallResult = await result.current.actions.presentPaywall();
+      });
+
+      expect(paywallResult.success).toBe(false);
+      expect(paywallResult.error).toBe('Paywall crashed');
+    });
+  });
+
+  describe('presentPaywallIfNeeded', () => {
+    test('refreshes after PURCHASED result', async () => {
+      mockPresentPaywallIfNeeded.mockResolvedValueOnce({ success: true, data: 'PURCHASED' });
+
+      const { result } = renderHook(
+        () => ({ state: useSubscription(), actions: useSubscriptionActions() }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      const customerInfoCallsBefore = mockGetCustomerInfo.mock.calls.length;
+
+      await act(async () => {
+        await result.current.actions.presentPaywallIfNeeded();
+      });
+
+      expect(mockGetCustomerInfo.mock.calls.length).toBeGreaterThan(customerInfoCallsBefore);
+    });
+
+    test('does not refresh when NOT_PRESENTED', async () => {
+      mockPresentPaywallIfNeeded.mockResolvedValueOnce({ success: true, data: 'NOT_PRESENTED' });
+
+      const { result } = renderHook(
+        () => ({ state: useSubscription(), actions: useSubscriptionActions() }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      const customerInfoCallsBefore = mockGetCustomerInfo.mock.calls.length;
+
+      await act(async () => {
+        await result.current.actions.presentPaywallIfNeeded();
+      });
+
+      expect(mockGetCustomerInfo.mock.calls.length).toBe(customerInfoCallsBefore);
+    });
+
+    test('returns error on failure without throwing', async () => {
+      mockPresentPaywallIfNeeded.mockRejectedValueOnce(new Error('Failed'));
+
+      const { result } = renderHook(
+        () => ({ state: useSubscription(), actions: useSubscriptionActions() }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      let paywallResult;
+      await act(async () => {
+        paywallResult = await result.current.actions.presentPaywallIfNeeded();
+      });
+
+      expect(paywallResult.success).toBe(false);
+      expect(paywallResult.error).toBe('Failed');
+    });
+  });
+
+  describe('presentCustomerCenter', () => {
+    test('refreshes after successful customer center', async () => {
+      mockPresentCustomerCenter.mockResolvedValueOnce({ success: true, data: null });
+
+      const { result } = renderHook(
+        () => ({ state: useSubscription(), actions: useSubscriptionActions() }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      const customerInfoCallsBefore = mockGetCustomerInfo.mock.calls.length;
+
+      await act(async () => {
+        await result.current.actions.presentCustomerCenter();
+      });
+
+      expect(mockGetCustomerInfo.mock.calls.length).toBeGreaterThan(customerInfoCallsBefore);
+    });
+
+    test('does not refresh on failure', async () => {
+      mockPresentCustomerCenter.mockResolvedValueOnce({ success: false, error: 'CC error' });
+
+      const { result } = renderHook(
+        () => ({ state: useSubscription(), actions: useSubscriptionActions() }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      const customerInfoCallsBefore = mockGetCustomerInfo.mock.calls.length;
+
+      await act(async () => {
+        await result.current.actions.presentCustomerCenter();
+      });
+
+      expect(mockGetCustomerInfo.mock.calls.length).toBe(customerInfoCallsBefore);
+    });
+
+    test('returns error on failure without throwing', async () => {
+      mockPresentCustomerCenter.mockRejectedValueOnce(new Error('Center crashed'));
+
+      const { result } = renderHook(
+        () => ({ state: useSubscription(), actions: useSubscriptionActions() }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      let centerResult;
+      await act(async () => {
+        centerResult = await result.current.actions.presentCustomerCenter();
+      });
+
+      expect(centerResult.success).toBe(false);
+      expect(centerResult.error).toBe('Center crashed');
+    });
+  });
+
   describe('real-time listener backend resync', () => {
     test('listener triggers backend status resync to update backendCanGenerate', async () => {
       const { result } = renderHook(() => useSubscription(), { wrapper });

--- a/hooks/useSubscription.js
+++ b/hooks/useSubscription.js
@@ -20,7 +20,11 @@ import {
   restorePurchases as restorePurchasesService,
   getCustomerInfo,
   onCustomerInfoUpdate,
-  parseCustomerInfo
+  parseCustomerInfo,
+  presentPaywall as presentPaywallService,
+  presentPaywallIfNeeded as presentPaywallIfNeededService,
+  presentCustomerCenter as presentCustomerCenterService,
+  PAYWALL_RESULT
 } from '../services/subscriptionService';
 import { fetchSubscriptionStatus } from '../services/subscriptionStatusService';
 import { subscribeAuthEvents, getCurrentUserId } from '../services/authService';
@@ -509,6 +513,45 @@ export const SubscriptionProvider = ({ children }) => {
     }
   }, []);
 
+  const handlePresentPaywall = useCallback(async (options) => {
+    try {
+      const result = await presentPaywallService(options);
+      if (result.success && (result.data === PAYWALL_RESULT.PURCHASED || result.data === PAYWALL_RESULT.RESTORED)) {
+        await refresh();
+      }
+      return result;
+    } catch (error) {
+      Sentry.captureException(error, { extra: { context: 'present_paywall' } });
+      return { success: false, error: error.message };
+    }
+  }, [refresh]);
+
+  const handlePresentPaywallIfNeeded = useCallback(async (options) => {
+    try {
+      const result = await presentPaywallIfNeededService(options);
+      if (result.success && (result.data === PAYWALL_RESULT.PURCHASED || result.data === PAYWALL_RESULT.RESTORED)) {
+        await refresh();
+      }
+      return result;
+    } catch (error) {
+      Sentry.captureException(error, { extra: { context: 'present_paywall_if_needed' } });
+      return { success: false, error: error.message };
+    }
+  }, [refresh]);
+
+  const handlePresentCustomerCenter = useCallback(async () => {
+    try {
+      const result = await presentCustomerCenterService();
+      if (result.success) {
+        await refresh();
+      }
+      return result;
+    } catch (error) {
+      Sentry.captureException(error, { extra: { context: 'present_customer_center' } });
+      return { success: false, error: error.message };
+    }
+  }, [refresh]);
+
   const canGenerate = useMemo(
     () => {
       if (state.backendCanGenerate !== null) return state.backendCanGenerate;
@@ -536,6 +579,9 @@ export const SubscriptionProvider = ({ children }) => {
         purchasePackage: handlePurchasePackage,
         restorePurchases: handleRestorePurchases,
         getOfferings: handleGetOfferings,
+        presentPaywall: handlePresentPaywall,
+        presentPaywallIfNeeded: handlePresentPaywallIfNeeded,
+        presentCustomerCenter: handlePresentCustomerCenter,
         dismissOnboarding,
         dismissLapseModal
       }
@@ -546,6 +592,9 @@ export const SubscriptionProvider = ({ children }) => {
       handlePurchasePackage,
       handleRestorePurchases,
       handleGetOfferings,
+      handlePresentPaywall,
+      handlePresentPaywallIfNeeded,
+      handlePresentCustomerCenter,
       dismissOnboarding,
       dismissLapseModal
     ]

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -20,4 +20,24 @@ jest.mock('react-native-purchases', () => ({
   restorePurchases: jest.fn().mockResolvedValue({ entitlements: { active: {} } }),
   getCustomerInfo: jest.fn().mockResolvedValue({ entitlements: { active: {} } }),
   addCustomerInfoUpdateListener: jest.fn().mockReturnValue(() => {}),
+  setLogLevel: jest.fn(),
+  LOG_LEVEL: { DEBUG: 'DEBUG', INFO: 'INFO', WARN: 'WARN', ERROR: 'ERROR' },
+}));
+
+jest.mock('react-native-purchases-ui', () => ({
+  __esModule: true,
+  default: {
+    presentPaywall: jest.fn().mockResolvedValue('CANCELLED'),
+    presentPaywallIfNeeded: jest.fn().mockResolvedValue('NOT_PRESENTED'),
+    presentCustomerCenter: jest.fn().mockResolvedValue(undefined),
+    Paywall: jest.fn(() => null),
+    CustomerCenterView: jest.fn(() => null),
+  },
+  PAYWALL_RESULT: {
+    PURCHASED: 'PURCHASED',
+    RESTORED: 'RESTORED',
+    CANCELLED: 'CANCELLED',
+    NOT_PRESENTED: 'NOT_PRESENTED',
+    ERROR: 'ERROR',
+  },
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "react-native": "0.81.4",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-purchases": "^9.14.0",
+        "react-native-purchases-ui": "^9.14.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-url-polyfill": "^2.0.0",
@@ -14193,6 +14194,7 @@
       "resolved": "https://registry.npmjs.org/react-native-purchases/-/react-native-purchases-9.14.0.tgz",
       "integrity": "sha512-wfTI5D54lQPUYP06t5Re0o+sAJXUpZ8s3BrPwpDtyChppJaSH2l7MlSeolY4BT3ij/rdpFjzaOsjIHQxTCDQWA==",
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "examples/purchaseTesterTypescript",
         "react-native-purchases-ui"
@@ -14204,6 +14206,26 @@
       "peerDependencies": {
         "react": ">= 16.6.3",
         "react-native": ">= 0.73.0",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-purchases-ui": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-native-purchases-ui/-/react-native-purchases-ui-9.14.0.tgz",
+      "integrity": "sha512-mpeBpz6RISe3cSTXeq0wiY6fDaGWMp4md1Qr1L9uaRuoZguXlPeDIYfKfYY8hJPS0EnHEpydZBYtlqOsg623SA==",
+      "license": "MIT",
+      "dependencies": {
+        "@revenuecat/purchases-typescript-internal": "17.52.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">= 0.73.0",
+        "react-native-purchases": "9.14.0",
         "react-native-web": "*"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-native": "0.81.4",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-purchases": "^9.14.0",
+    "react-native-purchases-ui": "^9.14.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-url-polyfill": "^2.0.0",

--- a/screens/SubscriptionScreen.js
+++ b/screens/SubscriptionScreen.js
@@ -17,19 +17,20 @@ import { useToast } from '../components/StatusToast';
 import { useCreditActions } from '../hooks/useCredits';
 import { grantAddonCredits } from '../services/subscriptionStatusService';
 import { getCurrentUserId } from '../services/authService';
+import { PAYWALL_RESULT } from '../services/subscriptionService';
 import { COLORS } from '../styles/colors';
 import { STORAGE_KEYS } from '../services/config';
-import * as Linking from 'expo-linking';
 import { formatDate } from '../utils/formatDate';
 import { pluralizeDays } from '../utils/pluralize';
 import { styles } from './styles/subscriptionScreenStyles';
 
-const FEATURES = [
+const FEATURES_BASE = [
   { icon: 'mic', label: 'Klonowanie głosu rodzica' },
   { icon: 'book-open', label: 'Generowanie spersonalizowanych bajek' },
-  { icon: 'headphones', label: 'Odtwarzanie offline' },
-  { icon: 'star', label: '26 Punktów Magii miesięcznie' }
+  { icon: 'headphones', label: 'Odtwarzanie offline' }
 ];
+
+const CREDITS_PER_PLAN = { MONTHLY: 26, ANNUAL: 30 };
 
 const ADDON_PACKS_CONFIG = [
   { id: 'credits_10', credits: 10 },
@@ -107,7 +108,14 @@ export default function SubscriptionScreen() {
     trial,
     canGenerate
   } = useSubscription();
-  const { purchasePackage, restorePurchases, getOfferings, refresh } = useSubscriptionActions();
+  const {
+    purchasePackage,
+    restorePurchases,
+    getOfferings,
+    presentPaywall,
+    presentCustomerCenter,
+    refresh
+  } = useSubscriptionActions();
   const creditActions = useCreditActions();
 
   const [offerings, setOfferings] = useState(null);
@@ -116,6 +124,7 @@ export default function SubscriptionScreen() {
   const [purchasing, setPurchasing] = useState(false);
   const [restoring, setRestoring] = useState(false);
   const [purchasingAddon, setPurchasingAddon] = useState(null);
+  const [selectedPlan, setSelectedPlan] = useState('MONTHLY');
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -144,18 +153,44 @@ export default function SubscriptionScreen() {
     loadOfferings();
   }, [loadOfferings]);
 
+  const monthlyPackage = offerings?.current?.availablePackages?.find(
+    (p) => p.packageType === 'MONTHLY'
+  );
+  const yearlyPackage = offerings?.current?.availablePackages?.find(
+    (p) => p.packageType === 'ANNUAL'
+  );
+
+  const monthlyPrice = monthlyPackage?.product?.priceString || null;
+  const yearlyPrice = yearlyPackage?.product?.priceString || null;
+  const priceLoading = loadingOfferings || (!offerings && !offeringsError);
+
+  const selectedPackage = selectedPlan === 'ANNUAL' ? yearlyPackage : monthlyPackage;
+  const selectedPrice = selectedPlan === 'ANNUAL' ? yearlyPrice : monthlyPrice;
+
+  const handleShowPaywall = async () => {
+    setPurchasing(true);
+    try {
+      const result = await presentPaywall({ displayCloseButton: true });
+      if (result.success && (result.data === PAYWALL_RESULT.PURCHASED || result.data === PAYWALL_RESULT.RESTORED)) {
+        showToast('Subskrypcja aktywowana!', 'SUCCESS');
+      }
+    } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'show_paywall' } });
+      showToast('Nie udało się wyświetlić oferty. Spróbuj ponownie.', 'ERROR');
+    } finally {
+      setPurchasing(false);
+    }
+  };
+
   const handlePurchase = async () => {
-    const monthlyPackage = offerings?.current?.availablePackages?.find(
-      (p) => p.packageType === 'MONTHLY'
-    ) || offerings?.current?.availablePackages?.[0];
-    if (!monthlyPackage) {
+    if (!selectedPackage) {
       showToast('Brak dostępnych planów. Spróbuj ponownie później.', 'ERROR');
       return;
     }
 
     setPurchasing(true);
     try {
-      const result = await purchasePackage(monthlyPackage);
+      const result = await purchasePackage(selectedPackage);
       if (result.success) {
         showToast('Subskrypcja aktywowana!', 'SUCCESS');
       } else if (result.code !== 'USER_CANCELLED' && result.error !== 'USER_CANCELLED') {
@@ -311,7 +346,6 @@ export default function SubscriptionScreen() {
 
         // transactionIdentifier is a RevenueCat-assigned ID, not an App Store/Play Store receipt.
         // The backend receives it as receipt_token and uses it as an idempotency key.
-        const currentUserId = await getCurrentUserId();
         const grantData = {
           transactionId: matchedTransaction.transactionIdentifier,
           productId: pack.id,
@@ -334,22 +368,21 @@ export default function SubscriptionScreen() {
     }
   };
 
-  const handleManageSubscription = () => {
-    const url = Platform.OS === 'ios'
-      ? 'https://apps.apple.com/account/subscriptions'
-      : 'https://play.google.com/store/account/subscriptions';
+  const handleManageSubscription = async () => {
+    const result = await presentCustomerCenter();
+    if (!result.success) {
+      // Fallback to platform subscription management URL
+      const url = Platform.OS === 'ios'
+        ? 'https://apps.apple.com/account/subscriptions'
+        : 'https://play.google.com/store/account/subscriptions';
 
-    Linking.openURL(url).catch((err) => {
-      Sentry.captureException(err, { extra: { context: 'manage_subscription_link' } });
-      showToast('Nie udało się otworzyć ustawień subskrypcji.', 'ERROR');
-    });
+      const { openURL } = await import('expo-linking');
+      openURL(url).catch((err) => {
+        Sentry.captureException(err, { extra: { context: 'manage_subscription_link' } });
+        showToast('Nie udało się otworzyć ustawień subskrypcji.', 'ERROR');
+      });
+    }
   };
-
-  const monthlyPackage = offerings?.current?.availablePackages?.find(
-    (p) => p.packageType === 'MONTHLY'
-  ) || offerings?.current?.availablePackages?.[0];
-  const priceLabel = monthlyPackage?.product?.priceString || null;
-  const priceLoading = loadingOfferings || (!offerings && !offeringsError);
 
   const addonPacks = ADDON_PACKS_CONFIG.map((pack) => ({
     ...pack,
@@ -440,7 +473,7 @@ export default function SubscriptionScreen() {
                 <Text style={styles.activeBadgeText}>Aktywna</Text>
               </View>
 
-              <Text style={styles.planTitle}>Plan Miesięczny</Text>
+              <Text style={styles.planTitle}>DawnoTemu Premium</Text>
 
               {expirationDate && (
                 <View style={styles.detailRow}>
@@ -454,8 +487,7 @@ export default function SubscriptionScreen() {
               <View style={styles.separator} />
 
               <Text style={styles.manageHint}>
-                Aby anulować lub zmienić plan, przejdź do ustawień subskrypcji w{' '}
-                {Platform.OS === 'ios' ? 'App Store' : 'Google Play'}.
+                Zarządzaj subskrypcją, anuluj lub poproś o zwrot.
               </Text>
 
               <TouchableOpacity
@@ -463,7 +495,7 @@ export default function SubscriptionScreen() {
                 onPress={handleManageSubscription}
               >
                 <Text style={styles.manageButtonText}>Zarządzaj subskrypcją</Text>
-                <Feather name="external-link" size={16} color={COLORS.lavender} />
+                <Feather name="settings" size={16} color={COLORS.lavender} />
               </TouchableOpacity>
             </View>
 
@@ -504,7 +536,7 @@ export default function SubscriptionScreen() {
             </Text>
 
             <View style={styles.featuresCard}>
-              {FEATURES.map((feature) => (
+              {FEATURES_BASE.map((feature) => (
                 <View key={feature.label} style={styles.featureRow}>
                   <View style={styles.featureIconContainer}>
                     <Feather name={feature.icon} size={18} color={COLORS.lavender} />
@@ -512,26 +544,77 @@ export default function SubscriptionScreen() {
                   <Text style={styles.featureText}>{feature.label}</Text>
                 </View>
               ))}
+              <View style={styles.featureRow}>
+                <View style={styles.featureIconContainer}>
+                  <Feather name="star" size={18} color={COLORS.lavender} />
+                </View>
+                <Text style={styles.featureText}>
+                  {CREDITS_PER_PLAN[selectedPlan] || 26} Punktów Magii miesięcznie
+                </Text>
+              </View>
             </View>
 
-            <View style={styles.planCard}>
-              <Text style={styles.planCardTitle}>Plan Miesięczny</Text>
-              {priceLoading ? (
-                <ActivityIndicator size="small" color={COLORS.lavender} style={styles.priceLoader} />
-              ) : priceLabel ? (
-                <>
-                  <Text style={styles.planPrice}>{priceLabel}</Text>
-                  <Text style={styles.planPeriod}>/ miesiąc</Text>
-                </>
-              ) : (
-                <Text style={styles.planPriceUnavailable}>Cena niedostępna</Text>
+            <View style={styles.planSelector}>
+              {monthlyPackage && (
+                <TouchableOpacity
+                  style={[
+                    styles.planCard,
+                    selectedPlan === 'MONTHLY' ? styles.planCardSelected : styles.planCardUnselected
+                  ]}
+                  onPress={() => setSelectedPlan('MONTHLY')}
+                  activeOpacity={0.85}
+                >
+                  <Text style={styles.planCardTitle}>Miesięczny</Text>
+                  {monthlyPrice ? (
+                    <>
+                      <Text style={styles.planPrice}>{monthlyPrice}</Text>
+                      <Text style={styles.planPeriod}>/ miesiąc</Text>
+                    </>
+                  ) : (
+                    <ActivityIndicator size="small" color={COLORS.lavender} style={styles.priceLoader} />
+                  )}
+                </TouchableOpacity>
+              )}
+
+              {yearlyPackage && (
+                <TouchableOpacity
+                  style={[
+                    styles.planCard,
+                    selectedPlan === 'ANNUAL' ? styles.planCardSelected : styles.planCardUnselected
+                  ]}
+                  onPress={() => setSelectedPlan('ANNUAL')}
+                  activeOpacity={0.85}
+                >
+                  <View style={styles.savingsBadge}>
+                    <Text style={styles.savingsBadgeText}>Najlepsza oferta</Text>
+                  </View>
+                  <Text style={styles.planCardTitle}>Roczny</Text>
+                  {yearlyPrice ? (
+                    <>
+                      <Text style={styles.planPrice}>{yearlyPrice}</Text>
+                      <Text style={styles.planPeriod}>/ rok</Text>
+                    </>
+                  ) : (
+                    <ActivityIndicator size="small" color={COLORS.lavender} style={styles.priceLoader} />
+                  )}
+                </TouchableOpacity>
               )}
             </View>
 
+            {!monthlyPackage && !yearlyPackage && !priceLoading && (
+              <View style={styles.planCard}>
+                <Text style={styles.planPriceUnavailable}>Plany chwilowo niedostępne</Text>
+              </View>
+            )}
+
+            {priceLoading && !monthlyPackage && !yearlyPackage && (
+              <ActivityIndicator size="small" color={COLORS.lavender} style={styles.priceLoader} />
+            )}
+
             <TouchableOpacity
-              style={[styles.purchaseButton, (purchasing || !priceLabel) && styles.disabledButton]}
+              style={[styles.purchaseButton, (purchasing || !selectedPrice) && styles.disabledButton]}
               onPress={handlePurchase}
-              disabled={purchasing || loadingOfferings || !priceLabel}
+              disabled={purchasing || loadingOfferings || !selectedPrice}
               activeOpacity={0.9}
             >
               {purchasing ? (
@@ -539,6 +622,15 @@ export default function SubscriptionScreen() {
               ) : (
                 <Text style={styles.purchaseButtonText}>Subskrybuj</Text>
               )}
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.paywallButton}
+              onPress={handleShowPaywall}
+              disabled={purchasing}
+            >
+              <Feather name="shopping-bag" size={16} color={COLORS.lavender} />
+              <Text style={styles.paywallButtonText}>Zobacz wszystkie oferty</Text>
             </TouchableOpacity>
 
             <TouchableOpacity

--- a/screens/SubscriptionScreen.js
+++ b/screens/SubscriptionScreen.js
@@ -10,6 +10,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Feather } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
+import * as Linking from 'expo-linking';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Sentry from '@sentry/react-native';
 import { useSubscription, useSubscriptionActions } from '../hooks/useSubscription';
@@ -66,8 +67,10 @@ const persistPendingAddonGrant = async (grantData) => {
       STORAGE_KEYS.PENDING_ADDON_GRANT,
       JSON.stringify({ ...grantData, createdAt: Date.now() })
     );
+    return true;
   } catch (err) {
     Sentry.captureException(err, { extra: { context: 'persist_pending_addon_grant' } });
+    return false;
   }
 };
 
@@ -92,6 +95,7 @@ const loadPendingAddonGrant = async () => {
     return parsed;
   } catch (err) {
     Sentry.captureException(err, { extra: { context: 'load_pending_addon_grant' } });
+    await clearPendingAddonGrant();
     return null;
   }
 };
@@ -142,7 +146,7 @@ export default function SubscriptionScreen() {
         setOfferingsError(result.error || 'Nie udało się załadować planów.');
       }
     } catch (err) {
-      Sentry.captureException(err);
+      Sentry.captureException(err, { extra: { context: 'load_offerings' } });
       setOfferingsError('Nie udało się załadować planów.');
     } finally {
       setLoadingOfferings(false);
@@ -167,27 +171,36 @@ export default function SubscriptionScreen() {
   const selectedPackage = selectedPlan === 'ANNUAL' ? yearlyPackage : monthlyPackage;
   const selectedPrice = selectedPlan === 'ANNUAL' ? yearlyPrice : monthlyPrice;
 
+  const purchaseInFlightRef = useRef(false);
+
   const handleShowPaywall = async () => {
+    if (purchaseInFlightRef.current) return;
+    purchaseInFlightRef.current = true;
     setPurchasing(true);
     try {
       const result = await presentPaywall({ displayCloseButton: true });
       if (result.success && (result.data === PAYWALL_RESULT.PURCHASED || result.data === PAYWALL_RESULT.RESTORED)) {
         showToast('Subskrypcja aktywowana!', 'SUCCESS');
+      } else if (!result.success) {
+        showToast('Nie udało się wyświetlić oferty. Spróbuj ponownie.', 'ERROR');
       }
     } catch (err) {
       Sentry.captureException(err, { extra: { context: 'show_paywall' } });
       showToast('Nie udało się wyświetlić oferty. Spróbuj ponownie.', 'ERROR');
     } finally {
       setPurchasing(false);
+      purchaseInFlightRef.current = false;
     }
   };
 
   const handlePurchase = async () => {
+    if (purchaseInFlightRef.current) return;
     if (!selectedPackage) {
       showToast('Brak dostępnych planów. Spróbuj ponownie później.', 'ERROR');
       return;
     }
 
+    purchaseInFlightRef.current = true;
     setPurchasing(true);
     try {
       const result = await purchasePackage(selectedPackage);
@@ -197,10 +210,11 @@ export default function SubscriptionScreen() {
         showToast('Nie udało się dokonać zakupu. Spróbuj ponownie.', 'ERROR');
       }
     } catch (err) {
-      Sentry.captureException(err);
+      Sentry.captureException(err, { extra: { context: 'subscription_purchase', plan: selectedPlan } });
       showToast('Wystąpił nieoczekiwany błąd. Spróbuj ponownie.', 'ERROR');
     } finally {
       setPurchasing(false);
+      purchaseInFlightRef.current = false;
     }
   };
 
@@ -216,7 +230,7 @@ export default function SubscriptionScreen() {
         showToast('Nie udało się przywrócić zakupów. Spróbuj ponownie.', 'ERROR');
       }
     } catch (err) {
-      Sentry.captureException(err);
+      Sentry.captureException(err, { extra: { context: 'restore_purchases' } });
       showToast('Wystąpił nieoczekiwany błąd. Spróbuj ponownie.', 'ERROR');
     } finally {
       setRestoring(false);
@@ -230,8 +244,6 @@ export default function SubscriptionScreen() {
       platform: grantData.platform
     });
 
-    if (!mountedRef.current) return grantResult;
-
     if (grantResult.success) {
       await clearPendingAddonGrant();
       Sentry.addBreadcrumb({
@@ -244,7 +256,6 @@ export default function SubscriptionScreen() {
           credits: grantData.credits
         }
       });
-      showToast(`Dodano ${grantData.credits} Punktów Magii!`, 'SUCCESS');
     } else {
       Sentry.captureMessage('grantAddonCredits failed after purchase', {
         level: 'error',
@@ -253,6 +264,13 @@ export default function SubscriptionScreen() {
           productId: grantData.productId
         }
       });
+    }
+
+    if (!mountedRef.current) return grantResult;
+
+    if (grantResult.success) {
+      showToast(`Dodano ${grantData.credits} Punktów Magii!`, 'SUCCESS');
+    } else {
       showToast('Zakup udany, ale nie udało się dodać punktów. Ponowimy automatycznie przy następnym uruchomieniu.', 'ERROR');
     }
 
@@ -275,7 +293,15 @@ export default function SubscriptionScreen() {
       const userId = await getCurrentUserId();
       if (!userId) return;
       const pending = await loadPendingAddonGrant();
-      if (!pending || !pending.transactionId || !pending.productId) return;
+      if (!pending) return;
+      if (!pending.transactionId || !pending.productId) {
+        Sentry.captureMessage('Pending addon grant has missing fields, cannot retry', {
+          level: 'error',
+          extra: { hasTransactionId: !!pending.transactionId, hasProductId: !!pending.productId }
+        });
+        await clearPendingAddonGrant();
+        return;
+      }
       if (!pending.userId || pending.userId !== String(userId)) {
         await clearPendingAddonGrant();
         return;
@@ -284,6 +310,9 @@ export default function SubscriptionScreen() {
     };
     retry().catch((err) => {
       Sentry.captureException(err, { extra: { context: 'pending_addon_grant_retry' } });
+      if (mountedRef.current) {
+        showToast('Mamy problem z naliczeniem punktów. Spróbuj ponownie lub skontaktuj się z nami.', 'ERROR');
+      }
     });
   }, [loading, attemptGrantAddonCredits]);
 
@@ -354,7 +383,13 @@ export default function SubscriptionScreen() {
           userId: String(currentUserId)
         };
 
-        await persistPendingAddonGrant(grantData);
+        const persisted = await persistPendingAddonGrant(grantData);
+        if (!persisted) {
+          Sentry.captureMessage('Addon grant safety net compromised: AsyncStorage write failed', {
+            level: 'error',
+            extra: { productId: pack.id, transactionId: grantData.transactionId }
+          });
+        }
         await attemptGrantAddonCredits(grantData);
       } else if (result.code !== 'USER_CANCELLED' && result.error !== 'USER_CANCELLED') {
         showToast('Nie udało się dokonać zakupu. Spróbuj ponownie.', 'ERROR');
@@ -369,18 +404,22 @@ export default function SubscriptionScreen() {
   };
 
   const handleManageSubscription = async () => {
-    const result = await presentCustomerCenter();
-    if (!result.success) {
-      // Fallback to platform subscription management URL
-      const url = Platform.OS === 'ios'
-        ? 'https://apps.apple.com/account/subscriptions'
-        : 'https://play.google.com/store/account/subscriptions';
-
-      const { openURL } = await import('expo-linking');
-      openURL(url).catch((err) => {
-        Sentry.captureException(err, { extra: { context: 'manage_subscription_link' } });
-        showToast('Nie udało się otworzyć ustawień subskrypcji.', 'ERROR');
-      });
+    try {
+      const result = await presentCustomerCenter();
+      if (!result.success) {
+        Sentry.captureMessage('Customer center failed, falling back to platform URL', {
+          level: 'warning',
+          extra: { error: result.error, platform: Platform.OS }
+        });
+        const url = Platform.OS === 'ios'
+          ? 'https://apps.apple.com/account/subscriptions'
+          : 'https://play.google.com/store/account/subscriptions';
+        await Linking.openURL(url);
+        showToast('Otwieram ustawienia subskrypcji w przeglądarce...', 'INFO');
+      }
+    } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'manage_subscription' } });
+      showToast('Nie udało się otworzyć ustawień subskrypcji.', 'ERROR');
     }
   };
 
@@ -549,7 +588,7 @@ export default function SubscriptionScreen() {
                   <Feather name="star" size={18} color={COLORS.lavender} />
                 </View>
                 <Text style={styles.featureText}>
-                  {CREDITS_PER_PLAN[selectedPlan] || 26} Punktów Magii miesięcznie
+                  {CREDITS_PER_PLAN[selectedPlan] ?? CREDITS_PER_PLAN.MONTHLY} Punktów Magii miesięcznie
                 </Text>
               </View>
             </View>

--- a/screens/__tests__/SubscriptionScreen.test.js
+++ b/screens/__tests__/SubscriptionScreen.test.js
@@ -89,8 +89,9 @@ jest.mock('../../styles/colors', () => ({
   }
 }));
 
+const mockOpenURL = jest.fn().mockResolvedValue(undefined);
 jest.mock('expo-linking', () => ({
-  openURL: jest.fn().mockResolvedValue(undefined)
+  openURL: mockOpenURL
 }));
 
 jest.mock('../../utils/formatDate', () => ({
@@ -195,6 +196,52 @@ describe('SubscriptionScreen', () => {
           expect.stringContaining('Nie udało się'),
           'ERROR'
         );
+      });
+    });
+  });
+
+  describe('double-tap prevention', () => {
+    test('second subscribe press while first is in-flight does not call purchasePackage again', async () => {
+      let resolveFirst;
+      mockPurchasePackage.mockImplementationOnce(
+        () => new Promise((resolve) => { resolveFirst = resolve; })
+      );
+
+      const { getByText, UNSAFE_root } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getByText('Subskrybuj')).toBeTruthy());
+
+      const subscribeButton = getByText('Subskrybuj').parent;
+      fireEvent.press(subscribeButton);
+
+      // Button now shows spinner, press the same touchable again
+      fireEvent.press(subscribeButton);
+
+      resolveFirst({ success: true, data: { customerInfo: { entitlements: { active: {} } } } });
+
+      await waitFor(() => {
+        expect(mockPurchasePackage).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    test('second paywall press while first is in-flight does not call presentPaywall again', async () => {
+      let resolveFirst;
+      mockPresentPaywall.mockImplementationOnce(
+        () => new Promise((resolve) => { resolveFirst = resolve; })
+      );
+
+      const { getByText } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getByText('Zobacz wszystkie oferty')).toBeTruthy());
+
+      const paywallButton = getByText('Zobacz wszystkie oferty').parent;
+      fireEvent.press(paywallButton);
+
+      // Press again while first is in flight
+      fireEvent.press(paywallButton);
+
+      resolveFirst({ success: true, data: 'PURCHASED' });
+
+      await waitFor(() => {
+        expect(mockPresentPaywall).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -383,13 +430,90 @@ describe('SubscriptionScreen', () => {
       });
     });
 
-    test('addon purchase blocked for non-subscribers', async () => {
+    test('addon buttons are disabled for non-subscribers', async () => {
       mockCurrentSubscriptionState = { ...mockSubscriptionState, isSubscribed: false };
 
+      mockGetOfferings.mockResolvedValue({
+        success: true,
+        data: {
+          current: {
+            availablePackages: [{ packageType: 'MONTHLY', product: { priceString: '29,99 zł', identifier: 'monthly' } }]
+          },
+          all: {
+            credit_packs: {
+              availablePackages: [
+                { product: { identifier: 'credits_10', priceString: '9,99 zł' } }
+              ]
+            }
+          }
+        }
+      });
+
       const { getByText } = render(<SubscriptionScreen />);
-      await waitFor(() => expect(getByText('Subskrybuj')).toBeTruthy());
+      await waitFor(() => expect(getByText('Dostępne tylko dla subskrybentów.')).toBeTruthy());
 
       expect(mockPurchasePackage).not.toHaveBeenCalled();
+    });
+
+    test('logs to Sentry when persist fails but still attempts grant', async () => {
+      const Sentry = require('@sentry/react-native');
+      mockCurrentSubscriptionState = {
+        ...mockSubscriptionState,
+        isSubscribed: true
+      };
+
+      mockGetOfferings.mockResolvedValue({
+        success: true,
+        data: {
+          current: {
+            availablePackages: [{ packageType: 'MONTHLY', product: { priceString: '29,99 zł', identifier: 'monthly' } }]
+          },
+          all: {
+            credit_packs: {
+              availablePackages: [
+                { product: { identifier: 'credits_10', priceString: '9,99 zł' } }
+              ]
+            }
+          }
+        }
+      });
+
+      mockPurchasePackage.mockResolvedValueOnce({
+        success: true,
+        data: {
+          customerInfo: {
+            entitlements: { active: { 'DawnoTemu Subscription': {} } },
+            nonSubscriptionTransactions: [
+              { productIdentifier: 'credits_10', transactionIdentifier: 'txn-persist-fail' }
+            ]
+          }
+        }
+      });
+
+      AsyncStorage.setItem.mockRejectedValueOnce(new Error('Disk full'));
+
+      mockGrantAddonCredits.mockResolvedValueOnce({
+        success: true,
+        data: { creditsGranted: 10, newBalance: 36 }
+      });
+
+      const { getAllByText } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getAllByText('10').length).toBeGreaterThan(0));
+
+      fireEvent.press(getAllByText('10')[0]);
+
+      await waitFor(() => {
+        expect(Sentry.captureMessage).toHaveBeenCalledWith(
+          'Addon grant safety net compromised: AsyncStorage write failed',
+          expect.objectContaining({ level: 'error' })
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockGrantAddonCredits).toHaveBeenCalledWith(
+          expect.objectContaining({ transactionId: 'txn-persist-fail' })
+        );
+      });
     });
 
     test('retries pending addon grant on mount when subscribed', async () => {
@@ -568,6 +692,203 @@ describe('SubscriptionScreen', () => {
 
       const { queryByText } = render(<SubscriptionScreen />);
       expect(queryByText('Subskrybuj')).toBeNull();
+    });
+  });
+
+  describe('paywall flow', () => {
+    test('successful paywall purchase shows success toast', async () => {
+      mockPresentPaywall.mockResolvedValueOnce({ success: true, data: 'PURCHASED' });
+
+      const { getByText } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getByText('Zobacz wszystkie oferty')).toBeTruthy());
+
+      fireEvent.press(getByText('Zobacz wszystkie oferty'));
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith('Subskrypcja aktywowana!', 'SUCCESS');
+      });
+    });
+
+    test('successful paywall restore shows success toast', async () => {
+      mockPresentPaywall.mockResolvedValueOnce({ success: true, data: 'RESTORED' });
+
+      const { getByText } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getByText('Zobacz wszystkie oferty')).toBeTruthy());
+
+      fireEvent.press(getByText('Zobacz wszystkie oferty'));
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith('Subskrypcja aktywowana!', 'SUCCESS');
+      });
+    });
+
+    test('paywall cancelled shows no toast', async () => {
+      mockPresentPaywall.mockResolvedValueOnce({ success: true, data: 'CANCELLED' });
+
+      const { getByText } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getByText('Zobacz wszystkie oferty')).toBeTruthy());
+
+      fireEvent.press(getByText('Zobacz wszystkie oferty'));
+
+      await waitFor(() => {
+        expect(mockPresentPaywall).toHaveBeenCalled();
+      });
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    test('paywall failure shows error toast', async () => {
+      mockPresentPaywall.mockResolvedValueOnce({ success: false, error: 'SDK error' });
+
+      const { getByText } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getByText('Zobacz wszystkie oferty')).toBeTruthy());
+
+      fireEvent.press(getByText('Zobacz wszystkie oferty'));
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.stringContaining('Nie udało się'),
+          'ERROR'
+        );
+      });
+    });
+  });
+
+  describe('manage subscription', () => {
+    test('successful customer center does not show toast', async () => {
+      mockCurrentSubscriptionState = {
+        ...mockSubscriptionState,
+        isSubscribed: true,
+        expirationDate: '2026-12-01'
+      };
+      mockPresentCustomerCenter.mockResolvedValueOnce({ success: true, data: null });
+
+      const { getByText } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getByText('Zarządzaj subskrypcją')).toBeTruthy());
+
+      fireEvent.press(getByText('Zarządzaj subskrypcją'));
+
+      await waitFor(() => {
+        expect(mockPresentCustomerCenter).toHaveBeenCalled();
+      });
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    test('customer center failure falls back to URL with info toast', async () => {
+      mockCurrentSubscriptionState = {
+        ...mockSubscriptionState,
+        isSubscribed: true,
+        expirationDate: '2026-12-01'
+      };
+      mockPresentCustomerCenter.mockResolvedValueOnce({ success: false, error: 'CC failed' });
+
+      const { getByText } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getByText('Zarządzaj subskrypcją')).toBeTruthy());
+
+      fireEvent.press(getByText('Zarządzaj subskrypcją'));
+
+      await waitFor(() => {
+        expect(mockOpenURL).toHaveBeenCalledWith(
+          expect.stringContaining('subscriptions')
+        );
+      });
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.stringContaining('przeglądarce'),
+        'INFO'
+      );
+    });
+  });
+
+  describe('manage subscription errors', () => {
+    test('customer center throw shows error toast', async () => {
+      mockCurrentSubscriptionState = {
+        ...mockSubscriptionState,
+        isSubscribed: true,
+        expirationDate: '2026-12-01'
+      };
+      mockPresentCustomerCenter.mockRejectedValueOnce(new Error('SDK crash'));
+
+      const { getByText } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getByText('Zarządzaj subskrypcją')).toBeTruthy());
+
+      fireEvent.press(getByText('Zarządzaj subskrypcją'));
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.stringContaining('Nie udało się otworzyć'),
+          'ERROR'
+        );
+      });
+    });
+
+    test('fallback URL failure shows error toast', async () => {
+      mockCurrentSubscriptionState = {
+        ...mockSubscriptionState,
+        isSubscribed: true,
+        expirationDate: '2026-12-01'
+      };
+      mockPresentCustomerCenter.mockResolvedValueOnce({ success: false, error: 'CC failed' });
+      mockOpenURL.mockRejectedValueOnce(new Error('Cannot open URL'));
+
+      const { getByText } = render(<SubscriptionScreen />);
+      await waitFor(() => expect(getByText('Zarządzaj subskrypcją')).toBeTruthy());
+
+      fireEvent.press(getByText('Zarządzaj subskrypcją'));
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.stringContaining('Nie udało się otworzyć'),
+          'ERROR'
+        );
+      });
+    });
+  });
+
+  describe('plan selection', () => {
+    test('renders yearly plan card when available', async () => {
+      mockGetOfferings.mockResolvedValue({
+        success: true,
+        data: {
+          current: {
+            availablePackages: [
+              { packageType: 'MONTHLY', product: { priceString: '29,99 zł', identifier: 'monthly' } },
+              { packageType: 'ANNUAL', product: { priceString: '249,99 zł', identifier: 'annual' } }
+            ]
+          }
+        }
+      });
+
+      const { getByText } = render(<SubscriptionScreen />);
+
+      await waitFor(() => {
+        expect(getByText('29,99 zł')).toBeTruthy();
+        expect(getByText('249,99 zł')).toBeTruthy();
+      });
+    });
+
+    test('switching to yearly plan updates credits display', async () => {
+      mockGetOfferings.mockResolvedValue({
+        success: true,
+        data: {
+          current: {
+            availablePackages: [
+              { packageType: 'MONTHLY', product: { priceString: '29,99 zł', identifier: 'monthly' } },
+              { packageType: 'ANNUAL', product: { priceString: '249,99 zł', identifier: 'annual' } }
+            ]
+          }
+        }
+      });
+
+      const { getByText } = render(<SubscriptionScreen />);
+
+      await waitFor(() => expect(getByText('Roczny')).toBeTruthy());
+
+      expect(getByText('26 Punktów Magii miesięcznie')).toBeTruthy();
+
+      fireEvent.press(getByText('Roczny'));
+
+      await waitFor(() => {
+        expect(getByText('30 Punktów Magii miesięcznie')).toBeTruthy();
+      });
     });
   });
 

--- a/screens/__tests__/SubscriptionScreen.test.js
+++ b/screens/__tests__/SubscriptionScreen.test.js
@@ -36,16 +36,31 @@ const mockRefresh = jest.fn().mockResolvedValue(undefined);
 
 let mockCurrentSubscriptionState = { ...mockSubscriptionState };
 
+const mockPresentPaywall = jest.fn().mockResolvedValue({ success: true, data: 'CANCELLED' });
+const mockPresentCustomerCenter = jest.fn().mockResolvedValue({ success: true, data: null });
+
 jest.mock('../../hooks/useSubscription', () => ({
   useSubscription: () => mockCurrentSubscriptionState,
   useSubscriptionActions: () => ({
     purchasePackage: mockPurchasePackage,
     restorePurchases: mockRestorePurchases,
     getOfferings: mockGetOfferings,
+    presentPaywall: mockPresentPaywall,
+    presentCustomerCenter: mockPresentCustomerCenter,
     refresh: mockRefresh,
     dismissOnboarding: jest.fn(),
     dismissLapseModal: jest.fn()
   })
+}));
+
+jest.mock('../../services/subscriptionService', () => ({
+  PAYWALL_RESULT: {
+    PURCHASED: 'PURCHASED',
+    RESTORED: 'RESTORED',
+    CANCELLED: 'CANCELLED',
+    NOT_PRESENTED: 'NOT_PRESENTED',
+    ERROR: 'ERROR',
+  }
 }));
 
 const mockRefreshCredits = jest.fn().mockResolvedValue(undefined);
@@ -132,7 +147,7 @@ describe('SubscriptionScreen', () => {
     test('successful purchase shows success toast', async () => {
       mockPurchasePackage.mockResolvedValueOnce({
         success: true,
-        data: { customerInfo: { entitlements: { active: { premium: {} } } } }
+        data: { customerInfo: { entitlements: { active: { 'DawnoTemu Subscription': {} } } } }
       });
 
       const { getByText } = render(<SubscriptionScreen />);
@@ -269,7 +284,7 @@ describe('SubscriptionScreen', () => {
         success: true,
         data: {
           customerInfo: {
-            entitlements: { active: { premium: {} } },
+            entitlements: { active: { 'DawnoTemu Subscription': {} } },
             nonSubscriptionTransactions: [
               { productIdentifier: 'credits_10', transactionIdentifier: 'txn-abc' }
             ]
@@ -334,7 +349,7 @@ describe('SubscriptionScreen', () => {
         success: true,
         data: {
           customerInfo: {
-            entitlements: { active: { premium: {} } },
+            entitlements: { active: { 'DawnoTemu Subscription': {} } },
             nonSubscriptionTransactions: [
               { productIdentifier: 'credits_10', transactionIdentifier: 'txn-xyz' }
             ]

--- a/screens/styles/subscriptionScreenStyles.js
+++ b/screens/styles/subscriptionScreenStyles.js
@@ -234,20 +234,46 @@ export const styles = StyleSheet.create({
     color: COLORS.text.primary,
     flex: 1
   },
+  planSelector: {
+    flexDirection: 'row',
+    width: '100%',
+    marginBottom: 20,
+    gap: 12
+  },
   planCard: {
+    flex: 1,
     backgroundColor: COLORS.white,
     borderRadius: 16,
     padding: 20,
-    width: '100%',
     alignItems: 'center',
-    marginBottom: 20,
     borderWidth: 2,
-    borderColor: COLORS.lavender,
+    borderColor: 'transparent',
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.04,
     shadowRadius: 10,
-    elevation: 1
+    elevation: 1,
+    position: 'relative'
+  },
+  planCardSelected: {
+    borderColor: COLORS.lavender
+  },
+  planCardUnselected: {
+    borderColor: 'rgba(0, 0, 0, 0.08)',
+    opacity: 0.75
+  },
+  savingsBadge: {
+    position: 'absolute',
+    top: -10,
+    backgroundColor: COLORS.peach,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 8
+  },
+  savingsBadgeText: {
+    fontFamily: 'Quicksand-Bold',
+    fontSize: 11,
+    color: COLORS.white
   },
   planCardTitle: {
     fontFamily: 'Quicksand-Medium',
@@ -291,6 +317,19 @@ export const styles = StyleSheet.create({
   },
   disabledButton: {
     opacity: 0.7
+  },
+  paywallButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    marginBottom: 4,
+    gap: 8
+  },
+  paywallButtonText: {
+    fontFamily: 'Quicksand-Medium',
+    fontSize: 14,
+    color: COLORS.lavender
   },
   restoreButton: {
     paddingVertical: 12,

--- a/services/__tests__/subscriptionService.test.js
+++ b/services/__tests__/subscriptionService.test.js
@@ -320,6 +320,29 @@ describe('subscriptionService', () => {
       expect(mockRevenueCatUI.presentPaywall).toHaveBeenCalledWith({ displayCloseButton: true });
     });
 
+    test('passes offering when provided', async () => {
+      const offering = { identifier: 'premium_offering' };
+      mockRevenueCatUI.presentPaywall.mockResolvedValue('PURCHASED');
+
+      const result = await service.presentPaywall({ offering, displayCloseButton: false });
+
+      expect(result.success).toBe(true);
+      expect(mockRevenueCatUI.presentPaywall).toHaveBeenCalledWith({
+        displayCloseButton: false,
+        offering
+      });
+    });
+
+    test('omits offering when not provided', async () => {
+      mockRevenueCatUI.presentPaywall.mockResolvedValue('CANCELLED');
+
+      await service.presentPaywall({ displayCloseButton: true });
+
+      const callArgs = mockRevenueCatUI.presentPaywall.mock.calls[0][0];
+      expect(callArgs).toEqual({ displayCloseButton: true });
+      expect(callArgs).not.toHaveProperty('offering');
+    });
+
     test('returns error on failure', async () => {
       mockRevenueCatUI.presentPaywall.mockRejectedValue(new Error('Paywall error'));
 
@@ -340,6 +363,19 @@ describe('subscriptionService', () => {
       expect(result.data).toBe('NOT_PRESENTED');
       expect(mockRevenueCatUI.presentPaywallIfNeeded).toHaveBeenCalledWith({
         requiredEntitlementIdentifier: 'DawnoTemu Subscription'
+      });
+    });
+
+    test('passes custom entitlement identifier when provided', async () => {
+      mockRevenueCatUI.presentPaywallIfNeeded.mockResolvedValue('PURCHASED');
+
+      const result = await service.presentPaywallIfNeeded({
+        requiredEntitlementIdentifier: 'Custom Entitlement'
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockRevenueCatUI.presentPaywallIfNeeded).toHaveBeenCalledWith({
+        requiredEntitlementIdentifier: 'Custom Entitlement'
       });
     });
 

--- a/services/__tests__/subscriptionService.test.js
+++ b/services/__tests__/subscriptionService.test.js
@@ -10,10 +10,30 @@ const mockPurchases = {
   purchasePackage: jest.fn(),
   restorePurchases: jest.fn(),
   getCustomerInfo: jest.fn(),
-  addCustomerInfoUpdateListener: jest.fn()
+  addCustomerInfoUpdateListener: jest.fn(),
+  setLogLevel: jest.fn(),
+  LOG_LEVEL: { DEBUG: 'DEBUG', INFO: 'INFO', WARN: 'WARN', ERROR: 'ERROR' }
 };
 
 jest.mock('react-native-purchases', () => mockPurchases);
+
+const mockRevenueCatUI = {
+  presentPaywall: jest.fn(),
+  presentPaywallIfNeeded: jest.fn(),
+  presentCustomerCenter: jest.fn()
+};
+
+jest.mock('react-native-purchases-ui', () => ({
+  __esModule: true,
+  default: mockRevenueCatUI,
+  PAYWALL_RESULT: {
+    PURCHASED: 'PURCHASED',
+    RESTORED: 'RESTORED',
+    CANCELLED: 'CANCELLED',
+    NOT_PRESENTED: 'NOT_PRESENTED',
+    ERROR: 'ERROR',
+  },
+}));
 
 describe('subscriptionService', () => {
   let service;
@@ -109,7 +129,7 @@ describe('subscriptionService', () => {
   describe('purchasePackage', () => {
     test('returns success with isActive when entitlement is present', async () => {
       const customerInfo = {
-        entitlements: { active: { premium: { expirationDate: '2026-12-01' } } }
+        entitlements: { active: { 'DawnoTemu Subscription': { expirationDate: '2026-12-01' } } }
       };
       mockPurchases.purchasePackage.mockResolvedValue({ customerInfo });
 
@@ -157,7 +177,7 @@ describe('subscriptionService', () => {
   describe('restorePurchases', () => {
     test('returns isActive based on entitlements', async () => {
       const customerInfo = {
-        entitlements: { active: { premium: {} } }
+        entitlements: { active: { 'DawnoTemu Subscription': {} } }
       };
       mockPurchases.restorePurchases.mockResolvedValue(customerInfo);
 
@@ -208,11 +228,11 @@ describe('subscriptionService', () => {
       expect(result.willRenew).toBe(false);
     });
 
-    test('returns subscribed with expiration when premium entitlement active', () => {
+    test('returns subscribed with expiration when entitlement active', () => {
       const result = service.parseCustomerInfo({
         entitlements: {
           active: {
-            premium: {
+            'DawnoTemu Subscription': {
               expirationDate: '2026-12-01T00:00:00Z',
               willRenew: true
             }
@@ -229,7 +249,7 @@ describe('subscriptionService', () => {
       const result = service.parseCustomerInfo({
         entitlements: {
           active: {
-            premium: {
+            'DawnoTemu Subscription': {
               expirationDate: '2026-12-01T00:00:00Z'
             }
           }
@@ -244,7 +264,7 @@ describe('subscriptionService', () => {
       const result = service.parseCustomerInfo({
         entitlements: {
           active: {
-            premium: { willRenew: true }
+            'DawnoTemu Subscription': { willRenew: true }
           }
         }
       });
@@ -286,6 +306,69 @@ describe('subscriptionService', () => {
       expect(result.isSubscribed).toBe(false);
       expect(result.expirationDate).toBeNull();
       expect(result.willRenew).toBe(false);
+    });
+  });
+
+  describe('presentPaywall', () => {
+    test('presents paywall and returns result on success', async () => {
+      mockRevenueCatUI.presentPaywall.mockResolvedValue('PURCHASED');
+
+      const result = await service.presentPaywall({ displayCloseButton: true });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe('PURCHASED');
+      expect(mockRevenueCatUI.presentPaywall).toHaveBeenCalledWith({ displayCloseButton: true });
+    });
+
+    test('returns error on failure', async () => {
+      mockRevenueCatUI.presentPaywall.mockRejectedValue(new Error('Paywall error'));
+
+      const result = await service.presentPaywall();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Paywall error');
+    });
+  });
+
+  describe('presentPaywallIfNeeded', () => {
+    test('presents paywall only if entitlement not active', async () => {
+      mockRevenueCatUI.presentPaywallIfNeeded.mockResolvedValue('NOT_PRESENTED');
+
+      const result = await service.presentPaywallIfNeeded();
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe('NOT_PRESENTED');
+      expect(mockRevenueCatUI.presentPaywallIfNeeded).toHaveBeenCalledWith({
+        requiredEntitlementIdentifier: 'DawnoTemu Subscription'
+      });
+    });
+
+    test('returns error on failure', async () => {
+      mockRevenueCatUI.presentPaywallIfNeeded.mockRejectedValue(new Error('Paywall error'));
+
+      const result = await service.presentPaywallIfNeeded();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Paywall error');
+    });
+  });
+
+  describe('presentCustomerCenter', () => {
+    test('presents customer center on success', async () => {
+      mockRevenueCatUI.presentCustomerCenter.mockResolvedValue(undefined);
+
+      const result = await service.presentCustomerCenter();
+
+      expect(result.success).toBe(true);
+    });
+
+    test('returns error on failure', async () => {
+      mockRevenueCatUI.presentCustomerCenter.mockRejectedValue(new Error('CC error'));
+
+      const result = await service.presentCustomerCenter();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('CC error');
     });
   });
 });

--- a/services/subscriptionService.js
+++ b/services/subscriptionService.js
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 import Purchases from 'react-native-purchases';
+import RevenueCatUI, { PAYWALL_RESULT } from 'react-native-purchases-ui';
 import * as Sentry from '@sentry/react-native';
 
 const REVENUECAT_API_KEYS = {
@@ -9,7 +10,8 @@ const REVENUECAT_API_KEYS = {
 
 // Must match the entitlement identifier in RevenueCat > Project > Entitlements.
 // A mismatch causes isSubscribed to always return false with no error.
-const ENTITLEMENT_ID = 'premium';
+// Dashboard path: RevenueCat > Project Settings > Entitlements > [identifier]
+const ENTITLEMENT_ID = 'DawnoTemu Subscription';
 
 const UNSUBSCRIBED_DEFAULT = { isSubscribed: false, expirationDate: null, willRenew: false };
 
@@ -22,6 +24,10 @@ const configure = async () => {
     if (!apiKey) {
       const platform = Platform.OS === 'ios' ? 'EXPO_PUBLIC_REVENUECAT_IOS_KEY' : 'EXPO_PUBLIC_REVENUECAT_ANDROID_KEY';
       return { success: false, error: `RevenueCat API key not configured. Set ${platform} in .env`, code: 'MISSING_API_KEY' };
+    }
+
+    if (__DEV__) {
+      Purchases.setLogLevel(Purchases.LOG_LEVEL.DEBUG);
     }
 
     await Purchases.configure({ apiKey });
@@ -144,6 +150,42 @@ const parseCustomerInfo = (customerInfo) => {
   };
 };
 
+const presentPaywall = async ({ offering, displayCloseButton = true } = {}) => {
+  try {
+    const options = { displayCloseButton };
+    if (offering) {
+      options.offering = offering;
+    }
+    const result = await RevenueCatUI.presentPaywall(options);
+    return { success: true, data: result };
+  } catch (error) {
+    Sentry.captureException(error, { extra: { context: 'revenuecat_present_paywall' } });
+    return { success: false, error: error.message, code: error.code };
+  }
+};
+
+const presentPaywallIfNeeded = async ({ requiredEntitlementIdentifier } = {}) => {
+  try {
+    const result = await RevenueCatUI.presentPaywallIfNeeded({
+      requiredEntitlementIdentifier: requiredEntitlementIdentifier || ENTITLEMENT_ID
+    });
+    return { success: true, data: result };
+  } catch (error) {
+    Sentry.captureException(error, { extra: { context: 'revenuecat_present_paywall_if_needed' } });
+    return { success: false, error: error.message, code: error.code };
+  }
+};
+
+const presentCustomerCenter = async () => {
+  try {
+    await RevenueCatUI.presentCustomerCenter();
+    return { success: true, data: null };
+  } catch (error) {
+    Sentry.captureException(error, { extra: { context: 'revenuecat_customer_center' } });
+    return { success: false, error: error.message, code: error.code };
+  }
+};
+
 export {
   configure,
   loginUser,
@@ -154,5 +196,9 @@ export {
   getCustomerInfo,
   onCustomerInfoUpdate,
   parseCustomerInfo,
-  ENTITLEMENT_ID
+  presentPaywall,
+  presentPaywallIfNeeded,
+  presentCustomerCenter,
+  ENTITLEMENT_ID,
+  PAYWALL_RESULT
 };


### PR DESCRIPTION
## Summary

- Install `react-native-purchases-ui` for native RevenueCat Paywall and Customer Center
- Update entitlement ID from `premium` to `DawnoTemu Subscription` (matches RevenueCat dashboard)
- Add yearly subscription plan support (`dawnotemu_annual` — 349 PLN/yr, 30 PM/mo, +15% bonus)
- Add `presentPaywall()`, `presentPaywallIfNeeded()`, and `presentCustomerCenter()` to subscription service and hook
- Replace platform URL "manage subscription" with RevenueCat Customer Center (with fallback)
- Add plan selector UI with monthly/yearly toggle and dynamic credits display (26 PM vs 30 PM)
- Enable `Purchases.setLogLevel(DEBUG)` in `__DEV__` mode
- Add `.env` to `.gitignore`

## Changed Files

| File | Change |
|---|---|
| `services/subscriptionService.js` | New entitlement ID, paywall/customer center functions, debug logging |
| `hooks/useSubscription.js` | Expose paywall/customer center actions, auto-refresh on purchase |
| `screens/SubscriptionScreen.js` | Yearly plan selector, native paywall button, customer center |
| `screens/styles/subscriptionScreenStyles.js` | Plan selector, savings badge, paywall button styles |
| `jest.setup.js` | Add `react-native-purchases-ui` mock |
| `package.json` | Add `react-native-purchases-ui` dependency |
| `.gitignore` | Add `.env` |
| `**/tests/**` | Update entitlement ID to `DawnoTemu Subscription` across all test files |

## Test plan

- [x] All 186 tests pass (16 suites)
- [ ] Verify RevenueCat paywall renders on iOS/Android dev build
- [ ] Verify Customer Center opens from subscribed state
- [ ] Verify yearly plan card renders when `dawnotemu_annual` is configured in RevenueCat
- [ ] Verify monthly/yearly toggle updates credits display (26 vs 30 PM)
- [ ] Verify fallback to platform URL when Customer Center fails
- [ ] Verify add-on purchase flow still works for subscribers