### PR TITLE
chore(release): v1.4.0 + EAS Update channel setup

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "DawnoTemu",
     "slug": "dawnotemu",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "orientation": "portrait",
     "icon": "./assets/images/logo.png",
     "scheme": "dawnotemu",

--- a/eas.json
+++ b/eas.json
@@ -16,6 +16,7 @@
     "preview": {
       "developmentClient": false,
       "distribution": "internal",
+      "channel": "preview",
       "env": {
         "SENTRY_AUTH_TOKEN": "${SENTRY_AUTH_TOKEN}",
         "SENTRY_ORG": "dawnotemu",
@@ -24,6 +25,7 @@
     },
     "production": {
       "autoIncrement": true,
+      "channel": "production",
       "env": {
         "SENTRY_AUTH_TOKEN": "${SENTRY_AUTH_TOKEN}",
         "SENTRY_ORG": "dawnotemu",


### PR DESCRIPTION
## Summary

- Bump app version 1.3.0 → 1.4.0 (build numbers auto-increment via EAS)
- Add `channel: "production"` to production build profile, `channel: "preview"` to preview profile

## Why

Production binaries 1.2.0 and 1.3.0 were built **without a channel field** in eas.json, so expo-updates omits the `expo-channel-name` request header at runtime. Expo's update server requires that header to route bundles to a branch — without it every manifest request returns **404**.

Verified by inspection:
- Android AAB `AndroidManifest.xml`: no `expo.modules.updates.UPDATES_CHANNEL` meta-data
- iOS IPA `Expo.plist`: no `EXUpdatesRequestHeaders` key
- `eas channel:list` empty (zero channels exist in the project)
- Manual `curl https://u.expo.dev/<projectId>/manifest` with runtime 1.1.0 → 404 with or without channel header

Net effect: zero OTA deliveries possible to current production users despite `expo-updates` being enabled in the binary.

## What this release ships

- **Sentry noise fixes** from #23 baked into the native binary (eliminates ~20 of 25 mobile Sentry issues)
- **Correct channel config** so v1.4.0+ binaries can receive OTA updates
- **Foundation** for future bug fixes to ship without store review (~5 min OTA vs 1-7 day review)

## Post-merge required (one-time EAS setup)

```bash
eas channel:create production --branch production
eas channel:create preview --branch preview
```

This creates the channel-to-branch mapping. Without it, the binary will send `expo-channel-name: production` but the server has no branch to serve.

## Test plan

- [x] `eas.json` valid (verified by reading + diff)
- [x] `app.json` version bumped, runtimeVersion unchanged at "1.1.0" (preserves OTA-bundle compatibility across future 1.4.x patches without forcing rebuild)
- [ ] After merge: `eas channel:create production --branch production`
- [ ] After merge: `eas build --platform all --profile production`
- [ ] After build: verify channel meta-data present in artifacts (`unzip` AAB, grep manifest for `UPDATES_CHANNEL`; same for `Expo.plist` `EXUpdatesRequestHeaders`)
- [ ] Submit to App Store + Play Console
- [ ] After approval: first OTA test by publishing a no-op update

🤖 Generated with [Claude Code](https://claude.com/claude-code)