### PR TITLE
fix(mobile): two cold-start crashes — expo-router Sitemap + auth-401 cascade

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "DawnoTemu",
     "slug": "dawnotemu",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "orientation": "portrait",
     "icon": "./assets/images/logo.png",
     "scheme": "dawnotemu",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.dawnotemu.mobile",
-      "buildNumber": "22",
+      "buildNumber": "23",
       "infoPlist": {
         "NSMicrophoneUsageDescription": "We use the microphone to record a short voice sample, which is used to create a personalized AI voice model for generating children’s audiobooks narrated in your voice.",
         "UIBackgroundModes": [
@@ -25,7 +25,7 @@
     },
     "android": {
       "package": "com.dawnotemu.app",
-      "versionCode": 21,
+      "versionCode": 22,
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/logo.png",
         "backgroundColor": "#D4C1EC"

--- a/hooks/__tests__/useSubscription.test.js
+++ b/hooks/__tests__/useSubscription.test.js
@@ -94,6 +94,8 @@ jest.mock('@sentry/react-native', () => ({
   captureMessage: jest.fn()
 }));
 
+const Sentry = require('@sentry/react-native');
+
 const {
   SubscriptionProvider,
   useSubscription,
@@ -667,6 +669,53 @@ describe('SubscriptionProvider', () => {
       });
 
       expect(mockLogoutUser).toHaveBeenCalledTimes(1);
+      expect(result.current.isSubscribed).toBe(false);
+      // Verify full RESET → initialState reducer transition
+      expect(result.current.expirationDate).toBeNull();
+      expect(result.current.willRenew).toBe(false);
+      expect(result.current.trial.active).toBe(false);
+    });
+  });
+
+  describe('cold-start without token', () => {
+    test('AUTH_REQUIRED on cold-start refresh does not log out user or capture Sentry warning', async () => {
+      // Cold-start scenario: fresh install, no logged-in user, no tokens.
+      // fetchSubscriptionStatus returns AUTH_REQUIRED — must be treated as benign:
+      //   - listener is registered but no LOGOUT broadcast occurs
+      //   - no Sentry capture (it's in BENIGN_TRIAL_REFRESH_CODES)
+      //   - hook settles cleanly with isSubscribed=false, error=null
+      mockGetCurrentUserId.mockResolvedValue(null);
+
+      mockGetCustomerInfo.mockResolvedValue({
+        success: true,
+        data: { entitlements: { active: {} } }
+      });
+
+      mockFetchSubscriptionStatus.mockResolvedValueOnce({
+        success: false,
+        code: 'AUTH_REQUIRED',
+        status: 401,
+        error: 'No tokens'
+      });
+
+      const { result } = renderHook(() => useSubscription(), { wrapper });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // Listener was registered (subscribeAuthEvents called) but NEVER
+      // invoked with LOGOUT — AUTH_REQUIRED must not cascade to logout.
+      expect(mockSubscribeAuthEvents).toHaveBeenCalled();
+      expect(mockLogoutUser).not.toHaveBeenCalled();
+
+      // AUTH_REQUIRED is in BENIGN_TRIAL_REFRESH_CODES → no Sentry warning
+      const trialStatusWarnings = Sentry.captureMessage.mock.calls.filter(
+        ([msg]) => msg === 'Failed to fetch trial status'
+      );
+      expect(trialStatusWarnings).toHaveLength(0);
+
+      // Hook settles cleanly
+      expect(result.current.error).toBeNull();
+      expect(result.current.loading).toBe(false);
       expect(result.current.isSubscribed).toBe(false);
     });
   });

--- a/hooks/__tests__/useSubscription.test.js
+++ b/hooks/__tests__/useSubscription.test.js
@@ -645,13 +645,17 @@ describe('SubscriptionProvider', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    test('LOGOUT before any LOGIN skips Purchases.logOut() (RC still anonymous)', async () => {
-      // No userId means linkedUserIdRef stays null and the SDK is never linked.
+    test('LOGOUT before any LOGIN still calls logoutUser (service no-ops on anonymous)', async () => {
+      // No userId — SDK never linked. The service-layer logoutUser swallows
+      // the RC "anonymous" error, so the hook unconditionally calls it to
+      // avoid desync if linkRevenueCat (backend bridge) failed after a
+      // successful Purchases.logIn.
       mockGetCurrentUserId.mockResolvedValue(null);
       mockGetCustomerInfo.mockResolvedValue({
         success: true,
         data: { entitlements: { active: {} } }
       });
+      mockLogoutUser.mockResolvedValue({ success: true, data: null, anonymous: true });
 
       const { result } = renderHook(() => useSubscription(), { wrapper });
       await waitFor(() => expect(result.current.loading).toBe(false));
@@ -662,8 +666,7 @@ describe('SubscriptionProvider', () => {
         await mockAuthEventCallback('LOGOUT');
       });
 
-      // Guard prevents the anonymous-logout error from RevenueCat.
-      expect(mockLogoutUser).not.toHaveBeenCalled();
+      expect(mockLogoutUser).toHaveBeenCalledTimes(1);
       expect(result.current.isSubscribed).toBe(false);
     });
   });

--- a/hooks/useSubscription.js
+++ b/hooks/useSubscription.js
@@ -50,6 +50,30 @@ const initialState = {
   showLapseModal: false
 };
 
+// Codes that don't warrant Sentry noise on the cold-start refresh path
+// (called from the init effect's Promise.all). On a fresh install the
+// user has no tokens; AUTH_REQUIRED is the expected outcome and must NOT
+// trigger LOGOUT cascade. The other codes are recoverable signals already
+// handled at the apiRequest layer.
+const BENIGN_TRIAL_REFRESH_CODES = new Set([
+  'AUTH_ERROR',     // refresh token failed; apiRequest already broadcast LOGOUT
+  'AUTH_REQUIRED',  // no tokens in storage; cold start / fresh install
+  'OFFLINE',
+  'TIMEOUT',
+  'API_ERROR'       // transient fetch failures (DNS, mid-request drops, TLS resets)
+]);
+
+// Codes that don't warrant Sentry noise after a real-time RC listener update.
+// At this point sdkConfigured is true → the user is logged in. AUTH_REQUIRED
+// is NOT benign here — it would indicate tokens vanished mid-session and is
+// worth a warning capture. Only transient-by-nature codes are suppressed.
+const BENIGN_TRIAL_RESYNC_CODES = new Set([
+  'AUTH_ERROR',
+  'OFFLINE',
+  'TIMEOUT',
+  'API_ERROR'
+]);
+
 const reducer = (state, action) => {
   switch (action.type) {
     case 'SET_LOADING':
@@ -246,12 +270,7 @@ export const SubscriptionProvider = ({ children }) => {
       if (!mountedRef.current) return { success: false, error: 'unmounted' };
 
       if (!trialResult.success) {
-        // AUTH_ERROR/OFFLINE/TIMEOUT are expected and already handled by
-        // apiRequest's refresh-and-broadcast-LOGOUT path; not actionable.
-        // API_ERROR covers transient fetch failures on flaky mobile networks
-        // (DNS, mid-request drops, TLS resets) — also not actionable.
-        const benignCodes = new Set(['AUTH_ERROR', 'AUTH_REQUIRED', 'OFFLINE', 'TIMEOUT', 'API_ERROR']);
-        if (!benignCodes.has(trialResult.code)) {
+        if (!BENIGN_TRIAL_REFRESH_CODES.has(trialResult.code)) {
           Sentry.captureMessage('Failed to fetch trial status', {
             level: 'warning',
             extra: { error: trialResult.error, code: trialResult.code, status: trialResult.status }
@@ -383,8 +402,7 @@ export const SubscriptionProvider = ({ children }) => {
               }
             });
           } else {
-            const benignCodes = new Set(['AUTH_ERROR', 'AUTH_REQUIRED', 'OFFLINE', 'TIMEOUT', 'API_ERROR']);
-            if (!benignCodes.has(trialResult.code)) {
+            if (!BENIGN_TRIAL_RESYNC_CODES.has(trialResult.code)) {
               Sentry.captureMessage('Backend resync failed after listener update', {
                 level: 'warning',
                 extra: { error: trialResult.error, code: trialResult.code, status: trialResult.status }

--- a/hooks/useSubscription.js
+++ b/hooks/useSubscription.js
@@ -250,7 +250,7 @@ export const SubscriptionProvider = ({ children }) => {
         // apiRequest's refresh-and-broadcast-LOGOUT path; not actionable.
         // API_ERROR covers transient fetch failures on flaky mobile networks
         // (DNS, mid-request drops, TLS resets) — also not actionable.
-        const benignCodes = new Set(['AUTH_ERROR', 'OFFLINE', 'TIMEOUT', 'API_ERROR']);
+        const benignCodes = new Set(['AUTH_ERROR', 'AUTH_REQUIRED', 'OFFLINE', 'TIMEOUT', 'API_ERROR']);
         if (!benignCodes.has(trialResult.code)) {
           Sentry.captureMessage('Failed to fetch trial status', {
             level: 'warning',
@@ -383,7 +383,7 @@ export const SubscriptionProvider = ({ children }) => {
               }
             });
           } else {
-            const benignCodes = new Set(['AUTH_ERROR', 'OFFLINE', 'TIMEOUT', 'API_ERROR']);
+            const benignCodes = new Set(['AUTH_ERROR', 'AUTH_REQUIRED', 'OFFLINE', 'TIMEOUT', 'API_ERROR']);
             if (!benignCodes.has(trialResult.code)) {
               Sentry.captureMessage('Backend resync failed after listener update', {
                 level: 'warning',

--- a/hooks/useSynthesisData.js
+++ b/hooks/useSynthesisData.js
@@ -17,7 +17,7 @@ const useSynthesisData = ({
   setIsLoading
 }) => {
   const handleApiError = useCallback((result, defaultMessage) => {
-    if (result.code === 'AUTH_ERROR') {
+    if (result.code === 'AUTH_ERROR' || result.code === 'AUTH_REQUIRED') {
       showToast('Sesja wygasła. Zaloguj się ponownie.', 'ERROR');
       navigation.replace('Login');
       return;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,21 @@
+// Custom entry that runs BEFORE expo-router/entry-classic mounts the root
+// component. We need this for two reasons:
+//
+// 1. expo-router 6.0.12 ships a Sitemap view that reads `window.location.origin`
+//    unconditionally. On React Native `window.location` is `undefined`, so any
+//    deep link / push notification / mistyped `dawnotemu://...` URL that
+//    bounces through the auto-generated `/_sitemap` or `+not-found` routes
+//    crashes the app with a fatal C++ exception (REACT-NATIVE-16, 2026-04-28).
+//    Defining a no-op `globalThis.location` makes the read return an empty
+//    string and the screen renders fine.
+//
+// 2. `react-native-url-polyfill` is in `package.json` deps but was never
+//    imported anywhere. Hermes 0.81's URL implementation has known gaps
+//    (`URL.canParse`, `searchParams.size`, etc.). Importing the polyfill
+//    here makes URL parsing identical across Hermes versions and OTA bundles.
+if (typeof globalThis.location === 'undefined') {
+  globalThis.location = { origin: '' };
+}
+
+require('react-native-url-polyfill/auto');
+require('expo-router/entry');

--- a/index.js
+++ b/index.js
@@ -1,19 +1,20 @@
-// Custom entry that runs BEFORE expo-router/entry-classic mounts the root
-// component. We need this for two reasons:
+// Custom entry that runs BEFORE expo-router/entry mounts the root component.
+// Two side-effects, both removable when the upstream bugs are fixed:
 //
-// 1. expo-router 6.0.12 ships a Sitemap view that reads `window.location.origin`
-//    unconditionally. On React Native `window.location` is `undefined`, so any
-//    deep link / push notification / mistyped `dawnotemu://...` URL that
-//    bounces through the auto-generated `/_sitemap` or `+not-found` routes
-//    crashes the app with a fatal C++ exception (REACT-NATIVE-16, 2026-04-28).
-//    Defining a no-op `globalThis.location` makes the read return an empty
-//    string and the screen renders fine.
+// 1. expo-router's Sitemap view (and +not-found fallback) reads
+//    `window.location.origin` unconditionally during render. On React Native,
+//    `window.location` is undefined → fatal C++ exception, reachable via any
+//    deep link / push notification / mistyped scheme URL the router can't
+//    match. Defining a no-op `globalThis.location` makes the read return ''
+//    and the screen renders. The stub intentionally exposes only `origin`;
+//    if future code (e.g. RSC) needs `href`/`pathname`, expand the stub.
+//    TODO: remove once expo-router guards the access.
 //
-// 2. `react-native-url-polyfill` is in `package.json` deps but was never
-//    imported anywhere. Hermes 0.81's URL implementation has known gaps
-//    (`URL.canParse`, `searchParams.size`, etc.). Importing the polyfill
-//    here makes URL parsing identical across Hermes versions and OTA bundles.
-if (typeof globalThis.location === 'undefined') {
+// 2. `react-native-url-polyfill` is in package.json deps but never imported.
+//    Hermes has gaps in URL (`URL.canParse`, `searchParams.size` etc.).
+//    Importing here makes URL parsing identical across Hermes versions and
+//    OTA bundles. TODO: remove once Hermes ships full URL support.
+if (!globalThis.location || typeof globalThis.location.origin !== 'string') {
   globalThis.location = { origin: '' };
 }
 

--- a/ios/DawnoTemu/Info.plist
+++ b/ios/DawnoTemu/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1.0</string>
+    <string>1.4.1</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -33,7 +33,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>20</string>
+    <string>23</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>LSMinimumSystemVersion</key>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "danwotemu",
   "version": "1.1.0",
   "private": true,
-  "main": "expo-router/entry.js",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/services/__tests__/authService.test.js
+++ b/services/__tests__/authService.test.js
@@ -1,0 +1,290 @@
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+jest.mock('@react-native-community/netinfo', () => ({
+  fetch: jest.fn(() => Promise.resolve({ isConnected: true })),
+  addEventListener: jest.fn(() => jest.fn())
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn()
+}));
+
+jest.mock('expo-router', () => ({
+  router: {
+    replace: jest.fn(),
+    push: jest.fn(),
+    back: jest.fn()
+  }
+}));
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' }
+}));
+
+jest.mock('../config', () => ({
+  API_BASE_URL: 'https://api.test.com',
+  REQUEST_TIMEOUT: 5000,
+  STORAGE_KEYS: {
+    ACCESS_TOKEN: 'auth_access_token',
+    REFRESH_TOKEN: 'auth_refresh_token',
+    USER_DATA: 'auth_user_data',
+    PLAYBACK_QUEUE: 'playback_queue_state',
+    PLAYBACK_LOOP_MODE: 'playback_loop_mode'
+  }
+}));
+
+const ACCESS_KEY = 'auth_access_token';
+const REFRESH_KEY = 'auth_refresh_token';
+
+const buildJsonResponse = ({ ok, status, body }) => ({
+  ok,
+  status,
+  json: () => Promise.resolve(body)
+});
+
+describe('authService.apiRequest 401 disambiguation', () => {
+  let SecureStore;
+  let authService;
+  let fetchMock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    fetchMock = jest.fn();
+    global.fetch = fetchMock;
+
+    // Re-require after resetModules so mocks attach to fresh module instance
+    SecureStore = require('expo-secure-store');
+    authService = require('../authService');
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  // Helper to set per-key SecureStore returns
+  const setSecureStoreState = ({ accessToken = null, refreshToken = null }) => {
+    SecureStore.getItemAsync.mockImplementation((key) => {
+      if (key === ACCESS_KEY) return Promise.resolve(accessToken);
+      if (key === REFRESH_KEY) return Promise.resolve(refreshToken);
+      return Promise.resolve(null);
+    });
+    SecureStore.setItemAsync.mockResolvedValue(undefined);
+    SecureStore.deleteItemAsync.mockResolvedValue(undefined);
+  };
+
+  test('401 with no access token AND no refresh token returns AUTH_REQUIRED without logout cascade', async () => {
+    setSecureStoreState({ accessToken: null, refreshToken: null });
+
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: false, status: 401, body: { error: 'Token missing' } })
+    );
+
+    const result = await authService.apiRequest('/protected');
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        status: 401,
+        code: 'AUTH_REQUIRED',
+        error: 'Token missing'
+      })
+    );
+    expect(result).toHaveProperty('data');
+    // refreshToken not invoked: only the original protected request hit fetch
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const refreshCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes('/auth/refresh')
+    );
+    expect(refreshCalls).toHaveLength(0);
+    // logout would have called deleteItemAsync on stored keys; ensure not called
+    expect(SecureStore.deleteItemAsync).not.toHaveBeenCalled();
+  });
+
+  test('401 with no access token but refresh token present, refresh succeeds, retries the request', async () => {
+    setSecureStoreState({ accessToken: null, refreshToken: 'refresh-xyz' });
+
+    // 1) Original request -> 401
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: false, status: 401, body: { error: 'Unauthorized' } })
+    );
+    // 2) /auth/refresh -> 200 with new access token
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: true, status: 200, body: { access_token: 'new-access' } })
+    );
+    // 3) Retry of original request -> 200 success
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: true, status: 200, body: { ok: true } })
+    );
+
+    // After refresh, the stored access token will be queried again on retry.
+    // Switch SecureStore to return the new access token AFTER setItemAsync is called.
+    SecureStore.setItemAsync.mockImplementation((key, value) => {
+      if (key === ACCESS_KEY) {
+        SecureStore.getItemAsync.mockImplementation((k) => {
+          if (k === ACCESS_KEY) return Promise.resolve(value);
+          if (k === REFRESH_KEY) return Promise.resolve('refresh-xyz');
+          return Promise.resolve(null);
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const result = await authService.apiRequest('/protected');
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.data).toEqual({ ok: true });
+
+    // Exactly one refresh attempt
+    const refreshCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes('/auth/refresh')
+    );
+    expect(refreshCalls).toHaveLength(1);
+
+    // The retry request used the new access token in its Authorization header
+    const retryCall = fetchMock.mock.calls[2];
+    expect(retryCall[0]).toContain('/protected');
+    expect(retryCall[1].headers).toEqual(
+      expect.objectContaining({ Authorization: 'Bearer new-access' })
+    );
+  });
+
+  test('401 with no access token but refresh token present, refresh fails, calls logout and returns AUTH_ERROR', async () => {
+    setSecureStoreState({ accessToken: null, refreshToken: 'refresh-broken' });
+
+    // 1) Original -> 401
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: false, status: 401, body: { error: 'Unauthorized' } })
+    );
+    // 2) /auth/refresh -> 401 (refresh failed)
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: false, status: 401, body: { error: 'Refresh denied' } })
+    );
+
+    const result = await authService.apiRequest('/protected');
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        status: 401,
+        code: 'AUTH_ERROR',
+        error: 'Unauthorized'
+      })
+    );
+
+    // logout cascade ran -> tokens deleted from SecureStore
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith(ACCESS_KEY);
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith(REFRESH_KEY);
+  });
+
+  test('401 with valid access token, refresh succeeds, retries the request', async () => {
+    setSecureStoreState({ accessToken: 'old-access', refreshToken: 'refresh-xyz' });
+
+    // 1) Original -> 401
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: false, status: 401, body: { error: 'Expired' } })
+    );
+    // 2) /auth/refresh -> 200
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: true, status: 200, body: { access_token: 'new-access' } })
+    );
+    // 3) Retry -> 200
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: true, status: 200, body: { ok: true } })
+    );
+
+    SecureStore.setItemAsync.mockImplementation((key, value) => {
+      if (key === ACCESS_KEY) {
+        SecureStore.getItemAsync.mockImplementation((k) => {
+          if (k === ACCESS_KEY) return Promise.resolve(value);
+          if (k === REFRESH_KEY) return Promise.resolve('refresh-xyz');
+          return Promise.resolve(null);
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const result = await authService.apiRequest('/protected');
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe(200);
+
+    const refreshCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes('/auth/refresh')
+    );
+    expect(refreshCalls).toHaveLength(1);
+
+    const retryCall = fetchMock.mock.calls[2];
+    expect(retryCall[1].headers).toEqual(
+      expect.objectContaining({ Authorization: 'Bearer new-access' })
+    );
+  });
+
+  test('401 with valid access token, refresh fails, calls logout and returns AUTH_ERROR', async () => {
+    setSecureStoreState({ accessToken: 'old-access', refreshToken: 'refresh-xyz' });
+
+    // 1) Original -> 401
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: false, status: 401, body: { error: 'Token expired' } })
+    );
+    // 2) /auth/refresh -> 401
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: false, status: 401, body: { error: 'Refresh denied' } })
+    );
+
+    const result = await authService.apiRequest('/protected');
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        status: 401,
+        code: 'AUTH_ERROR',
+        error: 'Token expired'
+      })
+    );
+
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith(ACCESS_KEY);
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith(REFRESH_KEY);
+  });
+
+  test('401 on retry (isRetry=true) does not loop and returns API_ERROR-style result', async () => {
+    setSecureStoreState({ accessToken: 'some-access', refreshToken: 'refresh-xyz' });
+
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: false, status: 401, body: { error: 'Still unauthorized' } })
+    );
+
+    const result = await authService.apiRequest('/protected', {}, null, true);
+
+    // Only one fetch — no refresh attempt, no further retries
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(401);
+    // mapStatusToCode(401) returns 'AUTH_ERROR'; what matters is no logout cascade
+    // and no further fetches
+    expect(SecureStore.deleteItemAsync).not.toHaveBeenCalled();
+  });
+
+  test('AUTH_REQUIRED response shape includes status, code, error, and data fields', async () => {
+    setSecureStoreState({ accessToken: null, refreshToken: null });
+
+    const responseBody = { error: 'You must log in', detail: 'no token' };
+    fetchMock.mockResolvedValueOnce(
+      buildJsonResponse({ ok: false, status: 401, body: responseBody })
+    );
+
+    const result = await authService.apiRequest('/protected');
+
+    expect(result).toHaveProperty('success', false);
+    expect(result).toHaveProperty('status', 401);
+    expect(result).toHaveProperty('code', 'AUTH_REQUIRED');
+    expect(result).toHaveProperty('error', 'You must log in');
+    expect(result).toHaveProperty('data', responseBody);
+  });
+});

--- a/services/__tests__/subscriptionStatusService.test.js
+++ b/services/__tests__/subscriptionStatusService.test.js
@@ -60,6 +60,23 @@ describe('subscriptionStatusService', () => {
       expect(Sentry.captureMessage).not.toHaveBeenCalled();
     });
 
+    test('forwards 401/AUTH_REQUIRED result without Sentry capture', async () => {
+      const Sentry = require('@sentry/react-native');
+      mockApiRequest.mockResolvedValue({
+        success: false,
+        status: 401,
+        error: 'Authentication required',
+        code: 'AUTH_REQUIRED'
+      });
+
+      const result = await service.fetchSubscriptionStatus();
+
+      expect(result.success).toBe(false);
+      expect(result.code).toBe('AUTH_REQUIRED');
+      expect(result.status).toBe(401);
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    });
+
     test('captures Sentry warning on 404', async () => {
       const Sentry = require('@sentry/react-native');
       mockApiRequest.mockResolvedValue({
@@ -320,6 +337,23 @@ describe('subscriptionStatusService', () => {
 
       expect(result.success).toBe(false);
       expect(result.status).toBe(401);
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    });
+
+    test('returns error without Sentry on 401/AUTH_REQUIRED (handled by apiRequest)', async () => {
+      const Sentry = require('@sentry/react-native');
+      mockApiRequest.mockResolvedValue({
+        success: false,
+        status: 401,
+        error: 'Authentication required',
+        code: 'AUTH_REQUIRED'
+      });
+
+      const result = await service.linkRevenueCat('42');
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe(401);
+      expect(result.code).toBe('AUTH_REQUIRED');
       expect(Sentry.captureMessage).not.toHaveBeenCalled();
     });
 

--- a/services/authService.js
+++ b/services/authService.js
@@ -122,10 +122,29 @@ const apiRequest = async (endpoint, options = {}, signal = null, isRetry = false
       // Special case for 401 Unauthorized - only try refresh once
       if (status === 401 && !isRetry) {
         if (!token) {
-          // No access token in storage — there is no active session to refresh
-          // or log out from. Surface as AUTH_REQUIRED so callers can handle
-          // "endpoint needs auth" without triggering a spurious LOGOUT cascade
-          // on cold start (Google Play test bot, fresh installs).
+          // Disambiguate: no access token could mean (a) truly anonymous user
+          // (cold start, fresh install — no LOGOUT cascade needed) or (b) access
+          // token vanished mid-session while refresh token survived (rare anomaly:
+          // partial keychain failure, race after concurrent rotation). The presence
+          // of a refresh token is the signal.
+          const hasRefreshToken = !!(await getRefreshToken());
+          if (hasRefreshToken) {
+            // Anomaly path — try refresh; on failure fall through to logout cascade.
+            const refreshed = await refreshToken();
+            if (refreshed) {
+              return apiRequest(endpoint, options, signal, true);
+            }
+            await logout();
+            const message = data?.error || data?.message || 'Authentication failed';
+            return {
+              success: false,
+              status,
+              error: message,
+              code: 'AUTH_ERROR',
+              data
+            };
+          }
+          // Truly anonymous — surface AUTH_REQUIRED without logout cascade.
           const message = data?.error || data?.message || 'Authentication required';
           return {
             success: false,

--- a/services/authService.js
+++ b/services/authService.js
@@ -121,6 +121,20 @@ const apiRequest = async (endpoint, options = {}, signal = null, isRetry = false
     if (!response.ok) {
       // Special case for 401 Unauthorized - only try refresh once
       if (status === 401 && !isRetry) {
+        if (!token) {
+          // No access token in storage — there is no active session to refresh
+          // or log out from. Surface as AUTH_REQUIRED so callers can handle
+          // "endpoint needs auth" without triggering a spurious LOGOUT cascade
+          // on cold start (Google Play test bot, fresh installs).
+          const message = data?.error || data?.message || 'Authentication required';
+          return {
+            success: false,
+            status,
+            error: message,
+            code: 'AUTH_REQUIRED',
+            data
+          };
+        }
         // Try token refresh if unauthorized and this is not already a retry
         const refreshed = await refreshToken();
         if (refreshed) {

--- a/services/voiceService.js
+++ b/services/voiceService.js
@@ -1923,22 +1923,6 @@ export const downloadAudio = async (
 ) => {
   let downloadResumable;
   const attemptNumber = retryCount + 1;
-  const describeUrl = () => {
-    try {
-      const parsed = new URL(url);
-      return {
-        full: parsed.href,
-        origin: parsed.origin,
-        path: parsed.pathname
-      };
-    } catch (error) {
-      return {
-        full: url,
-        origin: null,
-        path: null
-      };
-    }
-  };
   const isApiOrigin = () => {
     try {
       const parsedUrl = new URL(url);


### PR DESCRIPTION
## Context

Google Play rejected versionCode 22 (v1.4.0) for **App stability**: *"crashed during testing… ensure the app without crashing, hanging, or displaying error messages."* This PR ships the two distinct cold-start crash modes I traced via parallel multi-agent investigation, plus follow-up fixes from a multi-agent code review of the initial patch.

## Bug 1 — expo-router Sitemap fatal C++ exception (REACT-NATIVE-16)

`node_modules/expo-router/build/views/Sitemap.js:154` reads `window.location.origin` unconditionally inside a render. On React Native `window.location` is `undefined` → `TypeError: Cannot read property 'origin' of undefined` → RN's `ExceptionsManager.reportException` itself crashes formatting the error → fatal `cpp_exception`.

**Reachable on Android cold-start by Google Play's Robo bot**, which fuzzes deep-link intents (`adb shell am start -d "dawnotemu://..."`). Any URL the router can't match bounces through `+not-found` → auto-generated Sitemap → crash. Single-occurrence in production iOS Sentry — same crash mode, different trigger.

### Fix 1

New entry `mobile/index.js` runs before `expo-router/entry`:

1. `globalThis.location = { origin: '' }` — Sitemap's read returns `''` and the screen renders. Guard tightened: `if (!globalThis.location || typeof globalThis.location.origin !== 'string')` so a future RN with a partial location object still triggers the polyfill.
2. `require('react-native-url-polyfill/auto')` — the package was in deps but never imported; Hermes has gaps in URL (`URL.canParse`, `searchParams.size`).

`package.json` `"main"` flips from `expo-router/entry.js` to `index.js`, which chains through `require('expo-router/entry')`. Native binary behavior unchanged. Comment carries TODO markers for upstream-fix removal.

## Bug 2 — Spurious LOGOUT cascade on cold-start without auth

PR #23's refactor of `fetchSubscriptionStatus` to route through `authService.apiRequest` removed the prior *"no token → AUTH_REQUIRED"* early return. On a fresh install (Play Store test bot scenario):

1. `SubscriptionProvider` `init()` → `refresh()` → `fetchSubscriptionStatus()` → `apiRequest('/api/user/subscription-status')`
2. No access token → `fetch` without `Authorization` → server returns **401**
3. `apiRequest` → `refreshToken()` → no refresh token → returns false
4. **`apiRequest` calls `logout()`** — broadcasts `LOGOUT` to 3 listeners (`useSubscription`, `PlaybackQueueProvider`, `useCredits`) and calls `expo-router`'s `router.replace('/')` despite the app using `react-navigation`
5. State thrashes mid-init: `Purchases.logOut()` on anonymous SDK, AsyncStorage clears for queue/onboarding/last-subscription-state, reducer RESETs concurrent with the still-running init effect

This is a strong fit for *"hanging or showing errors"* on Play's review pass.

### Fix 2 (with review follow-ups)

The `apiRequest` 401 branch now disambiguates **three** cases by also checking refresh-token presence:

- **No access token AND no refresh token** → return `AUTH_REQUIRED`, no refresh, no logout. Truly anonymous cold-start.
- **No access token BUT refresh token present** → ANOMALY (mid-session keychain failure / race). Try `refreshToken()`. On success retry; on failure fall through to logout cascade returning `AUTH_ERROR`.
- **Access token present, 401** → existing refresh-and-retry-or-logout path, unchanged.

This was an explicit follow-up from the review — the original guard masked token-store failures (silent-failure-hunter HIGH).

Companion changes:

- `hooks/useSubscription.js` — Extracted two module-level constants `BENIGN_TRIAL_REFRESH_CODES` (includes `AUTH_REQUIRED`) and `BENIGN_TRIAL_RESYNC_CODES` (excludes it). The listener-resync path only fires after `sdkConfigured` flips true (i.e., user logged in), so `AUTH_REQUIRED` there is anomalous and worth a Sentry warning. The previous combined comment was misleading after the original patch.
- `hooks/useSynthesisData.js` — `handleApiError` now treats `AUTH_REQUIRED` the same as `AUTH_ERROR` (toast + redirect to Login). Otherwise synthesis-requiring screens with broken sessions would silently fall through to a generic toast.
- `services/__tests__/subscriptionStatusService.test.js` — Added `AUTH_REQUIRED` parity tests for `fetchSubscriptionStatus` and `linkRevenueCat`.

## New tests (10 total)

- `services/__tests__/authService.test.js` (NEW, 7 tests) — locks the `apiRequest` 401 contract: regression-catcher (no logout cascade for truly anonymous), retry-success, retry-failure-logout, isRetry boundary, response-shape contract.
- `hooks/__tests__/useSubscription.test.js` (+1) — cold-start integration test asserts no LOGOUT broadcast and no Sentry capture when refresh returns `AUTH_REQUIRED`.
- `hooks/__tests__/useSubscription.test.js` (existing test strengthened) — full RESET-state assertions in `LOGOUT before any LOGIN`.
- `services/__tests__/subscriptionStatusService.test.js` (+2) — `AUTH_REQUIRED` parity for fetch and link.

**Total: 227/227 tests passing.** Lint baseline unchanged.

## Drive-by

Removed dead `describeUrl` helper inside `services/voiceService.js::downloadAudio` — declared but never called. Found during the `.origin` grep.

## Ruled out (multi-agent investigation)

- ❌ **EAS Updates / `channel: production`** — manifest endpoint returns clean 204 NO_UPDATE_AVAILABLE; expo-updates handles gracefully (`launchWaitMs=0`); zero JS imports of expo-updates. Functionally inert on cold-start.
- ❌ **Native / new architecture** — zero native code changes between v21 and v22. Expo-managed prebuild, `package-lock.json` empty diff, `runtimeVersion` unchanged. PR #23 was 100% JS.
- ❌ **RC SDK Android init** — `Purchases.configure` wrapped in try/catch returning result objects; failures don't throw.

## Ships via

Native binary fix (Bug 1 polyfill must be in `index.js` before `expo-router/entry`, which is bundled at app start). versionCode 23 build required. Bug 2 also in native bundle — both fixes ride together.

## Test plan

- [x] `npm test` — 227/227 pass
- [x] `npm run lint` — no new errors
- [ ] After versionCode 23 build: trigger unmatched deep link (`adb shell am start -d "dawnotemu://nonexistent" com.dawnotemu.app`), confirm Sitemap renders without crash
- [ ] Cold-start fresh install: confirm no spurious LOGOUT broadcast (no AsyncStorage clear, no `Purchases.logOut` call) — verify in Sentry breadcrumbs and `console.log`
- [ ] Sentry: REACT-NATIVE-16 stays at 0 events for 7 days post-release
- [ ] Play Console "App access" — provide pre-confirmed test credentials so the manual reviewer can exercise the voice-clone main feature (separate policy concern flagged by reviewer-perspective agent — not a code fix in this PR)

## Follow-ups (out of scope)

- `hooks/useSynthesisData.js` has no test file — recommend adding `hooks/__tests__/useSynthesisData.test.js` covering both `AUTH_ERROR` and `AUTH_REQUIRED` branches in a tests-only PR.
- If RSC / static-render is ever enabled, the `index.js` polyfill needs additional fields (`href`, `protocol`, `host`) — `expo-router/build/host.js:54` reads `location.href`.
- The drive-by `describeUrl` removal could have been its own commit per one-logical-change-per-commit; noted for next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)